### PR TITLE
SOCINT-156: Set-up for 'register' journey

### DIFF
--- a/app/register_handlers.py
+++ b/app/register_handlers.py
@@ -1,0 +1,27 @@
+import aiohttp_jinja2
+from aiohttp.web import RouteTableDef
+from structlog import get_logger
+
+from .utils import View
+
+logger = get_logger('respondent-home')
+register_routes = RouteTableDef()
+
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/register/')
+class Register(View):
+    @aiohttp_jinja2.template('register.html')
+    async def get(self, request):
+        display_region = 'en'
+        page_title = 'Take part in a survey'
+        if request.get('flash'):
+            page_title = View.page_title_error_prefix_en + page_title
+        locale = 'en'
+        self.log_entry(request, display_region + '/register')
+
+        return {
+            'display_region': display_region,
+            'page_title': page_title,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+        }

--- a/app/routes.py
+++ b/app/routes.py
@@ -3,13 +3,14 @@ from aiohttp_utils.routing import add_resource_context
 from .web_form_handlers import web_form_routes
 from .request_handlers import request_routes
 from .start_handlers import start_routes
+from .register_handlers import register_routes
 from .handlers import static_routes
 
 
 def setup(app, url_path_prefix):
     """Set up routes as resources so we can use the `Index:get` notation for URL lookup."""
 
-    combined_routes = [*request_routes, *start_routes, *static_routes, *web_form_routes]
+    combined_routes = [*register_routes, *request_routes, *start_routes, *static_routes, *web_form_routes]
 
     for route in combined_routes:
         use_prefix = route.kwargs.get('use_prefix', True)

--- a/app/templates/base-en-register.html
+++ b/app/templates/base-en-register.html
@@ -1,0 +1,86 @@
+{%- extends 'layout/_template.njk' -%}
+
+{%- if page_title -%}
+    {%- set page_title_value = page_title + ' - ' + site_name_en -%}
+{%- else -%}
+    {%- set page_title_value = site_name_en -%}
+{%- endif -%}
+
+{%- set footer_content = {
+        'crest': true,
+        'rows': [
+            {
+                'itemsList': [
+                    {
+                        'text': 'Contact us',
+                        'url': domain_url_en + '/contact-us/'
+                    }
+                ]
+            }
+        ],
+        'legal': [
+            {
+                'itemsList': [
+                    {
+                        'text': 'Cookies',
+                        'url': domain_url_en + '/cookies/'
+                    },
+                    {
+                        'text': 'Accessibility statement',
+                        'url': domain_url_en + '/accessibility-statement/'
+                    },
+                    {
+                        'text': 'Privacy and data protection',
+                        'url': domain_url_en + '/privacy-and-data-protection/'
+                    },
+                    {
+                        'text': 'Terms and conditions',
+                        'url': domain_url_en + '/terms-and-conditions/'
+                    }
+                ]
+            }
+        ]
+    }
+-%}
+
+{%- set pageConfig = {
+    'title': page_title_value,
+    'header': {
+        'logoHref': 'https://www.ons.gov.uk/',
+        'title': site_name_en
+    },
+    'signoutButton': signout_button_value,
+    'footer': footer_content,
+    'cspNonce': cspNonce
+} -%}
+
+{%- block head -%}
+
+    <!-- Google Analytics -->
+    {%- if gtm_cont_id and gtm_auth -%}
+        {%- include 'partials/gtm.html' with context -%}
+    {%- endif -%}
+    <!-- End Google Analytics -->
+
+{%- endblock -%}
+
+{%- block bodyStart -%}
+
+    {%- if gtm_cont_id and gtm_auth -%}
+        {%- include 'partials/gtm-no-script.html' with context -%}
+    {%- endif -%}
+
+{%- endblock -%}
+
+{%- block preHeader -%}
+
+    {%- from 'components/cookies-banner/_macro.njk' import onsCookiesBanner -%}
+    {{
+        onsCookiesBanner({
+            "statementTitle": 'Tell us whether you accept cookies',
+            "statementText": 'We use <a href="' + domain_url_en + '/cookies' + '">cookies to collect information</a> about how you use surveys.ons.gov.uk. We use this information to make the website work as well as possible and improve our services.',
+            "confirmationText": 'You’ve accepted all cookies. You can <a href="' + domain_url_en + '/cookies' + '">change your cookie preferences</a> at any time.',
+            "secondaryButtonUrl": domain_url_en + '/cookies'
+        })
+    }}
+{%- endblock -%}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,18 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- from 'components/button/_macro.njk' import onsButton -%}
+
+{%- block main -%}
+
+    <h1 class="u-mb-xs u-fs-l">Take part in a survey</h1>
+
+    {{
+        onsButton({
+            'type': 'button',
+            'text': _('How to register a child'),
+            'classes': 'u-mb-m u-mt-m',
+            'url': '#'
+        })
+    }}
+
+{%- endblock main -%}

--- a/app/utils.py
+++ b/app/utils.py
@@ -32,6 +32,7 @@ uk_zone = timezone('Europe/London')
 
 class View:
     valid_display_regions = r'{display_region:\ben|cy\b}'
+    valid_display_regions_en_only = r'{display_region:\ben\b}'
     valid_user_journeys = r'{user_journey:\bstart|request\b}'
     page_title_error_prefix_en = 'Error: '
     page_title_error_prefix_cy = 'Gwall: '

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1003,6 +1003,9 @@ class RHTestCase(AioHTTPTestCase):
         self.content_web_form_error_429_title_en = 'You have reached the maximum number web form submissions'
         self.content_web_form_error_429_title_cy = "Allwch chi ddim cyflwyno mwy o ffurflenni gwe"
 
+        # Start Register
+        self.get_register_en = self.app.router['Register:get'].url_for(display_region='en')
+
         # yapf: enable
 
     # URL functions

--- a/tests/unit/test_register_handlers.py
+++ b/tests/unit/test_register_handlers.py
@@ -1,0 +1,28 @@
+from aiohttp.test_utils import unittest_run_loop
+
+from .helpers import TestHelpers
+
+
+# noinspection PyTypeChecker
+class TestWebFormHandlers(TestHelpers):
+    user_journey = 'register'
+    display_region = 'en'
+
+    def check_content_register(self, display_region, contents):
+        self.assertCorrectHeadTitleTag(display_region, 'Take part in a survey', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectPageTitle('Take part in a survey', contents)
+        self.assertIn('How to register a child', contents)
+
+    async def get_register(self, display_region):
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('GET', self.get_register_en)
+            self.assertLogEvent(cm, self.build_url_log_entry('register', display_region, 'GET',
+                                                             include_request_type=False, include_page=False))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register(display_region, str(await get_response.content.read()))
+
+    @unittest_run_loop
+    async def test_register(self):
+        await self.get_register('en')


### PR DESCRIPTION
# Motivation and Context
Basic set-up for the new 'register' journey

# What has changed
- Created new base template
- Created new register_handlers.py, and updated routes to detect it
- Created initial skeleton page
- Created initial unit test, to check skeleton page

# How to test?
Page can be viewed at /en/register/

# Links
https://collaborate2.ons.gov.uk/jira/browse/SOCINT-156