### PR TITLE
SOCINT-156 RHUI Register Journey for SIS2

### DIFF
--- a/app/data/schools.json
+++ b/app/data/schools.json
@@ -1,0 +1,32 @@
+[
+  {
+    "en": "The Aldgate School, City of London"
+  },
+  {
+    "en": "City of London School for Girls, City of London"
+  },
+  {
+    "en": "Brookfield Primary School, Camden"
+  },
+  {
+    "en": "Shoreditch Park Primary School, Hackney"
+  },
+  {
+    "en": "River House Montessori School, Tower Hamlets"
+  },
+  {
+    "en": "Locks Heath Junior School, Hampshire"
+  },
+  {
+    "en": "Four Marks Church of England Primary School, Hampshire"
+  },
+  {
+    "en": "Wootey Junior School, Hampshire"
+  },
+  {
+    "en": "Park Gate Primary School, Hampshire"
+  },
+  {
+    "en": "Titchfield Primary School, Hampshire"
+  }
+]

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -37,6 +37,10 @@ class TooManyRequestsEQLaunch(Exception):
     """Raised when EQ returns a 429 error"""
 
 
+class TooManyRequestsRegister(Exception):
+    """Raised when Register returns a 429 error"""
+
+
 class ExerciseClosedError(Exception):
     """Raised when a user attempts to access an already ended CE"""
     def __init__(self, collection_exercise_id):

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -1,6 +1,6 @@
 import aiohttp_jinja2
 
-from aiohttp.web import RouteTableDef, json_response, HTTPFound
+from aiohttp.web import RouteTableDef, json_response, HTTPFound, FileResponse
 from structlog import get_logger
 
 from . import VERSION
@@ -80,3 +80,9 @@ class SignedOut(View):
             'locale': locale,
             'page_url': View.gen_page_url(request)
         }
+
+
+@static_routes.view('/data/schools/')
+class SchoolsData(View):
+    async def get(self, request):
+        return FileResponse('app/data/schools.json')

--- a/app/register_handlers.py
+++ b/app/register_handlers.py
@@ -335,6 +335,8 @@ class RegisterConsent(View):
         locale = 'en'
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/consent')
 
+        await get_existing_session(request, user_journey, request_type)
+
         return {
             'display_region': display_region,
             'page_title': page_title,

--- a/app/register_handlers.py
+++ b/app/register_handlers.py
@@ -64,13 +64,14 @@ class RegisterStart(View):
 
         session = await get_existing_session(request, user_journey, request_type)
 
-        fulfilment_attributes = {
+        register_attributes = {
             'survey': 'sis2',
             'first_name': '',
             'middle_names': '',
-            'last_name': ''
+            'last_name': '',
+            'school_name': ''
         }
-        session['fulfilment_attributes'] = fulfilment_attributes
+        session['register_attributes'] = register_attributes
         session.changed()
         raise HTTPFound(
             request.app.router['RegisterEnterName:get'].url_for(display_region=display_region,
@@ -103,7 +104,7 @@ class RegisterConsent(View):
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/consent')
 
         session = await get_existing_session(request, user_journey, request_type)
-        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
 
         data = await request.post()
         logger.info(data)
@@ -113,7 +114,7 @@ class RegisterConsent(View):
                 request.app.router['RegisterConsentDeclined:get'].url_for(display_region=display_region,
                                                                           request_type=request_type))
         elif data.get('button-accept') == 'accept':
-            fulfilment_attributes['consent'] = 'accept'
+            register_attributes['consent'] = 'accept'
             session.changed()
             raise HTTPFound(
                 request.app.router['RegisterEnterMobile:get'].url_for(display_region=display_region,
@@ -176,7 +177,7 @@ class RegisterEnterMobile(View):
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/enter-mobile')
 
         session = await get_existing_session(request, user_journey, request_type)
-        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
 
         data = await request.post()
 
@@ -187,8 +188,8 @@ class RegisterEnterMobile(View):
             logger.info('valid mobile number',
                         client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
 
-            fulfilment_attributes['mobile_number'] = mobile_number
-            fulfilment_attributes['submitted_mobile_number'] = data['request-mobile-number']
+            register_attributes['mobile_number'] = mobile_number
+            register_attributes['submitted_mobile_number'] = data['request-mobile-number']
             session.changed()
 
             raise HTTPFound(
@@ -219,7 +220,7 @@ class RegisterConfirmRegistration(View):
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/confirm-registration')
 
         session = await get_existing_session(request, user_journey, request_type)
-        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
 
         page_title = 'Confirm your registration'
         if request.get('flash'):
@@ -231,7 +232,7 @@ class RegisterConfirmRegistration(View):
             'display_region': display_region,
             'locale': locale,
             'page_url': View.gen_page_url(request),
-            'submitted_mobile_number': get_session_value(request, fulfilment_attributes,
+            'submitted_mobile_number': get_session_value(request, register_attributes,
                                                          'submitted_mobile_number', user_journey)
         }
 
@@ -241,7 +242,7 @@ class RegisterConfirmRegistration(View):
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/confirm-registration')
 
         session = await get_existing_session(request, user_journey, request_type)
-        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
 
         data = await request.post()
         try:
@@ -256,7 +257,7 @@ class RegisterConfirmRegistration(View):
                 ))
 
         if mobile_confirmation == 'yes':
-            mobile_number = get_session_value(request, fulfilment_attributes, 'mobile_number',
+            mobile_number = get_session_value(request, register_attributes, 'mobile_number',
                                               user_journey, request_type)
 
             # TODO RHSvc Register Person call
@@ -294,7 +295,7 @@ class RegisterComplete(View):
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/complete')
 
         session = await get_existing_session(request, user_journey, request_type)
-        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
 
         page_title = 'Registration complete'
         locale = 'en'
@@ -307,7 +308,7 @@ class RegisterComplete(View):
             'locale': locale,
             'request_type': request_type,
             'page_url': View.gen_page_url(request),
-            'submitted_mobile_number': get_session_value(request, fulfilment_attributes,
+            'submitted_mobile_number': get_session_value(request, register_attributes,
                                                          'submitted_mobile_number', user_journey, request_type)
         }
 
@@ -329,7 +330,7 @@ class RegisterEnterName(View):
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/enter-name')
 
         session = await get_existing_session(request, user_journey, request_type)
-        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
 
         return {
             'page_title': page_title,
@@ -337,10 +338,10 @@ class RegisterEnterName(View):
             'locale': locale,
             'request_type': request_type,
             'page_url': View.gen_page_url(request),
-            'first_name': get_session_value(request, fulfilment_attributes, 'first_name', user_journey, request_type),
-            'middle_names': get_session_value(request, fulfilment_attributes,
+            'first_name': get_session_value(request, register_attributes, 'first_name', user_journey, request_type),
+            'middle_names': get_session_value(request, register_attributes,
                                               'middle_names', user_journey, request_type),
-            'last_name': get_session_value(request, fulfilment_attributes, 'last_name', user_journey, request_type)
+            'last_name': get_session_value(request, register_attributes, 'last_name', user_journey, request_type)
         }
 
     async def post(self, request):
@@ -350,7 +351,13 @@ class RegisterEnterName(View):
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/enter-name')
 
         session = await get_existing_session(request, user_journey, request_type)
-        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
+
+        if (get_session_value(request, register_attributes, 'first_name', user_journey, request_type) == '' and
+                get_session_value(request, register_attributes, 'last_name', user_journey, request_type) == ''):
+            journey = 'new'
+        else:
+            journey = 'change'
 
         data = await request.post()
 
@@ -373,14 +380,82 @@ class RegisterEnterName(View):
         name_middle_names = data['name_middle_names'].strip()
         name_last_name = data['name_last_name'].strip()
 
-        fulfilment_attributes['first_name'] = name_first_name
-        fulfilment_attributes['middle_names'] = name_middle_names
-        fulfilment_attributes['last_name'] = name_last_name
+        register_attributes['first_name'] = name_first_name
+        register_attributes['middle_names'] = name_middle_names
+        register_attributes['last_name'] = name_last_name
         session.changed()
 
-        raise HTTPFound(
-            request.app.router['RegisterPersonSummary:get'].url_for(display_region=display_region,
-                                                                    request_type=request_type))
+        if journey == 'new':
+            raise HTTPFound(
+                request.app.router['RegisterSelectSchool:get'].url_for(display_region=display_region,
+                                                                       request_type=request_type))
+        else:
+            raise HTTPFound(
+                request.app.router['RegisterPersonSummary:get'].url_for(display_region=display_region,
+                                                                        request_type=request_type))
+
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/' + user_journey + '/' +
+                      valid_registration_types + '/select-school/')
+class RegisterSelectSchool(View):
+    @aiohttp_jinja2.template('register-select-school.html')
+    async def get(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        page_title = 'Select school'
+        if request.get('flash'):
+            page_title = View.page_title_error_prefix_en + page_title
+        locale = 'en'
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/select-school')
+
+        session = await get_existing_session(request, user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
+        
+        return {
+            'display_region': display_region,
+            'page_title': page_title,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+            'request_type': request_type,
+            'first_name': get_session_value(request, register_attributes, 'first_name', user_journey, request_type),
+            'middle_names': get_session_value(request, register_attributes,
+                                              'middle_names', user_journey, request_type),
+            'last_name': get_session_value(request, register_attributes, 'last_name', user_journey, request_type),
+            'school_name': get_session_value(request, register_attributes, 'school_name', user_journey, request_type)
+        }
+
+    async def post(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/select-school')
+
+        session = await get_existing_session(request, user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
+
+        if get_session_value(request, register_attributes, 'school_name', user_journey, request_type) == '':
+            journey = 'new'
+        else:
+            journey = 'change'
+
+        data = await request.post()
+
+        if data.get('school-selection') and data.get('school-selection') != '':
+            register_attributes['school_name'] = data.get('school-selection')
+            session.changed()
+            if journey == 'new':
+                raise HTTPFound(
+                    request.app.router['RegisterPersonSummary:get'].url_for(display_region=display_region,
+                                                                            request_type=request_type))
+            else:
+                raise HTTPFound(
+                    request.app.router['RegisterPersonSummary:get'].url_for(display_region=display_region,
+                                                                            request_type=request_type))
+        else:
+            flash(request, {'text': 'Enter a value', 'level': 'ERROR', 'type': 'SCHOOL_ENTER_ERROR',
+                            'field': 'error_selection'})
+            raise HTTPFound(
+                request.app.router['RegisterSelectSchool:get'].url_for(display_region=display_region,
+                                                                       request_type=request_type))
 
 
 @register_routes.view(r'/' + View.valid_display_regions + '/' + user_journey + '/' + valid_registration_types +
@@ -394,7 +469,7 @@ class RegisterPersonSummary(View):
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/person-summary')
 
         session = await get_existing_session(request, user_journey, request_type)
-        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
 
         page_title = 'Person summary'
         locale = 'en'
@@ -405,10 +480,11 @@ class RegisterPersonSummary(View):
             'locale': locale,
             'request_type': request_type,
             'page_url': View.gen_page_url(request),
-            'first_name': get_session_value(request, fulfilment_attributes, 'first_name', user_journey, request_type),
-            'middle_names': get_session_value(request, fulfilment_attributes,
+            'first_name': get_session_value(request, register_attributes, 'first_name', user_journey, request_type),
+            'middle_names': get_session_value(request, register_attributes,
                                               'middle_names', user_journey, request_type),
-            'last_name': get_session_value(request, fulfilment_attributes, 'last_name', user_journey, request_type)
+            'last_name': get_session_value(request, register_attributes, 'last_name', user_journey, request_type),
+            'school_name': get_session_value(request, register_attributes, 'school_name', user_journey, request_type)
         }
 
     async def post(self, request):

--- a/app/register_handlers.py
+++ b/app/register_handlers.py
@@ -1,14 +1,26 @@
 import aiohttp_jinja2
-from aiohttp.web import RouteTableDef
+
+from aiohttp.client_exceptions import (ClientResponseError)
+from aiohttp.web import HTTPFound, RouteTableDef
 from structlog import get_logger
 
-from .utils import View
+from . import (NO_SELECTION_CHECK_MSG,
+               NO_SELECTION_CHECK_MSG_CY)
+
+from .flash import flash
+from .exceptions import TooManyRequestsRegister
+from .security import invalidate
+from .session import get_existing_session, get_session_value
+from .utils import View, ProcessMobileNumber, InvalidDataError, InvalidDataErrorWelsh, FlashMessage, RHService
 
 logger = get_logger('respondent-home')
 register_routes = RouteTableDef()
 
+user_journey = 'register'
+valid_registration_types = r'{request_type:\bperson\b}'
 
-@register_routes.view(r'/' + View.valid_display_regions_en_only + '/register/')
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/' + user_journey + '/')
 class Register(View):
     @aiohttp_jinja2.template('register.html')
     async def get(self, request):
@@ -17,11 +29,296 @@ class Register(View):
         if request.get('flash'):
             page_title = View.page_title_error_prefix_en + page_title
         locale = 'en'
-        self.log_entry(request, display_region + '/register')
+        self.log_entry(request, display_region + '/' + user_journey)
 
         return {
             'display_region': display_region,
             'page_title': page_title,
             'locale': locale,
             'page_url': View.gen_page_url(request),
+            'request_type': 'person'
+        }
+
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/' + user_journey + '/' +
+                      valid_registration_types + '/start/')
+class RegisterStart(View):
+    @aiohttp_jinja2.template('register-start.html')
+    async def get(self, request):
+        display_region = 'en'
+        page_title = 'Start registration'
+        if request.get('flash'):
+            page_title = View.page_title_error_prefix_en + page_title
+        locale = 'en'
+        self.log_entry(request, display_region + '/' + user_journey + '/' +
+                       valid_registration_types + '/start')
+
+        return {
+            'display_region': display_region,
+            'page_title': page_title,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+            'request_type': 'person'
+        }
+
+    async def post(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/start')
+
+        session = await get_existing_session(request, user_journey, request_type)
+
+        fulfilment_attributes = {'survey': 'sis2'}
+        session['fulfilment_attributes'] = fulfilment_attributes
+        session.changed()
+        raise HTTPFound(
+            request.app.router['RegisterConsent:get'].url_for(display_region=display_region,
+                                                              request_type=request_type))
+
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/' + user_journey + '/' +
+                      valid_registration_types + '/consent/')
+class RegisterConsent(View):
+    @aiohttp_jinja2.template('register-consent.html')
+    async def get(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        page_title = 'Confirm consent'
+        if request.get('flash'):
+            page_title = View.page_title_error_prefix_en + page_title
+        locale = 'en'
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/consent')
+
+        return {
+            'display_region': display_region,
+            'page_title': page_title,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+            'request_type': request_type
+        }
+
+    @aiohttp_jinja2.template('register-consent.html')
+    async def post(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/consent')
+
+        session = await get_existing_session(request, user_journey, request_type)
+        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+
+        data = await request.post()
+        logger.info(data)
+
+        if data.get('button-decline') == 'decline':
+            raise HTTPFound(
+                request.app.router['RegisterConsentDeclined:get'].url_for(display_region=display_region,
+                                                                          request_type=request_type))
+        elif data.get('button-accept') == 'accept':
+            fulfilment_attributes['consent'] = 'accept'
+            session.changed()
+            raise HTTPFound(
+                request.app.router['RegisterEnterMobile:get'].url_for(display_region=display_region,
+                                                                      request_type=request_type))
+        else:
+            raise HTTPFound(
+                request.app.router['RegisterConsent:get'].url_for(display_region=display_region,
+                                                                  request_type=request_type))
+
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/' + user_journey + '/' + valid_registration_types +
+                      '/consent-declined/')
+class RegisterConsentDeclined(View):
+    @aiohttp_jinja2.template('register-consent-declined.html')
+    async def get(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        page_title = 'You have been removed from this study'
+        if request.get('flash'):
+            page_title = View.page_title_error_prefix_en + page_title
+        locale = 'en'
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/consent-declined')
+
+        await invalidate(request)
+
+        return {
+            'display_region': display_region,
+            'page_title': page_title,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+        }
+
+
+@register_routes.view(r'/' + View.valid_display_regions + '/' + user_journey + '/' + valid_registration_types +
+                      '/enter-mobile/')
+class RegisterEnterMobile(View):
+    @aiohttp_jinja2.template('register-enter-mobile.html')
+    async def get(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        page_title = 'Enter mobile number'
+        if request.get('flash'):
+            page_title = View.page_title_error_prefix_en + page_title
+        locale = 'en'
+
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/enter-mobile')
+
+        await get_existing_session(request, user_journey, request_type)
+
+        return {
+            'page_title': page_title,
+            'display_region': display_region,
+            'locale': locale,
+            'page_url': View.gen_page_url(request)
+        }
+
+    async def post(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        if display_region == 'cy':
+            locale = 'cy'
+        else:
+            locale = 'en'
+
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/enter-mobile')
+
+        session = await get_existing_session(request, user_journey, request_type)
+        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+
+        data = await request.post()
+
+        try:
+            mobile_number = ProcessMobileNumber.validate_uk_mobile_phone_number(data['request-mobile-number'],
+                                                                                locale)
+
+            logger.info('valid mobile number',
+                        client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
+
+            fulfilment_attributes['mobile_number'] = mobile_number
+            fulfilment_attributes['submitted_mobile_number'] = data['request-mobile-number']
+            session.changed()
+
+            raise HTTPFound(
+                request.app.router['RegisterConfirmRegistration:get'].url_for(display_region=display_region,
+                                                                              request_type=request_type))
+
+        except (InvalidDataError, InvalidDataErrorWelsh) as exc:
+            logger.info(exc, client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
+            if exc.message_type == 'empty':
+                flash_message = FlashMessage.generate_flash_message(str(exc), 'ERROR', 'MOBILE_ENTER_ERROR',
+                                                                    'mobile_empty')
+            else:
+                flash_message = FlashMessage.generate_flash_message(str(exc), 'ERROR', 'MOBILE_ENTER_ERROR',
+                                                                    'mobile_invalid')
+            flash(request, flash_message)
+            raise HTTPFound(
+                request.app.router['RegisterEnterMobile:get'].url_for(display_region=display_region,
+                                                                      request_type=request_type))
+
+
+@register_routes.view(r'/' + View.valid_display_regions + '/' + user_journey + '/' + valid_registration_types +
+                      '/confirm-registration/')
+class RegisterConfirmRegistration(View):
+    @aiohttp_jinja2.template('register-confirm-registration.html')
+    async def get(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/confirm-registration')
+
+        session = await get_existing_session(request, user_journey, request_type)
+        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+
+        page_title = 'Confirm to send access code by text'
+        if request.get('flash'):
+            page_title = View.page_title_error_prefix_en + page_title
+        locale = 'en'
+
+        return {
+            'page_title': page_title,
+            'display_region': display_region,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+            'submitted_mobile_number': get_session_value(request, fulfilment_attributes,
+                                                         'submitted_mobile_number', user_journey)
+        }
+
+    async def post(self, request):
+        display_region = request.match_info['display_region']
+        request_type = request.match_info['request_type']
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/confirm-send-by-text')
+
+        session = await get_existing_session(request, user_journey, request_type)
+        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+
+        data = await request.post()
+        try:
+            mobile_confirmation = data['request-mobile-confirmation']
+        except KeyError:
+            logger.info('mobile confirmation error',
+                        client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
+            if display_region == 'cy':
+                flash(request, NO_SELECTION_CHECK_MSG_CY)
+            else:
+                flash(request, NO_SELECTION_CHECK_MSG)
+            raise HTTPFound(
+                request.app.router['RegisterConfirmRegistration:get'].url_for(
+                    display_region=display_region, request_type=request_type
+                ))
+
+        if mobile_confirmation == 'yes':
+            mobile_number = get_session_value(request, fulfilment_attributes, 'mobile_number',
+                                              user_journey, request_type)
+
+            # TODO RHSvc Register Person call
+
+            raise HTTPFound(
+                request.app.router['RegisterComplete:get'].url_for(display_region=display_region,
+                                                                   request_type=request_type))
+
+        elif mobile_confirmation == 'no':
+            raise HTTPFound(
+                request.app.router['RegisterEnterMobile:get'].url_for(display_region=display_region,
+                                                                      request_type=request_type))
+
+        else:
+            # catch all just in case, should never get here
+            logger.info('mobile confirmation error',
+                        client_ip=request['client_ip'],
+                        client_id=request['client_id'],
+                        trace=request['trace'],
+                        user_selection=mobile_confirmation)
+            if display_region == 'cy':
+                flash(request, NO_SELECTION_CHECK_MSG_CY)
+            else:
+                flash(request, NO_SELECTION_CHECK_MSG)
+            raise HTTPFound(
+                request.app.router['RegisterConfirmRegistration:get'].url_for(display_region=display_region,
+                                                                              request_type=request_type))
+
+
+@register_routes.view(r'/' + View.valid_display_regions + '/' + user_journey + '/' + valid_registration_types +
+                      '/complete/')
+class RegisterComplete(View):
+    @aiohttp_jinja2.template('register-complete.html')
+    async def get(self, request):
+        request_type = request.match_info['request_type']
+        display_region = request.match_info['display_region']
+
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/complete')
+
+        session = await get_existing_session(request, user_journey, request_type)
+        fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
+
+        page_title = 'Access code has been sent by text'
+        locale = 'en'
+
+        await invalidate(request)
+
+        return {
+            'page_title': page_title,
+            'display_region': display_region,
+            'locale': locale,
+            'request_type': request_type,
+            'page_url': View.gen_page_url(request),
+            'submitted_mobile_number': get_session_value(request, fulfilment_attributes,
+                                                         'submitted_mobile_number', user_journey, request_type)
         }

--- a/app/register_handlers.py
+++ b/app/register_handlers.py
@@ -26,8 +26,6 @@ class Register(View):
     async def get(self, request):
         display_region = 'en'
         page_title = 'Take part in a survey'
-        if request.get('flash'):
-            page_title = View.page_title_error_prefix_en + page_title
         locale = 'en'
         self.log_entry(request, display_region + '/' + user_journey)
 
@@ -46,12 +44,10 @@ class RegisterStart(View):
     @aiohttp_jinja2.template('register-start.html')
     async def get(self, request):
         display_region = 'en'
+        request_type = request.match_info['request_type']
         page_title = 'Start registration'
-        if request.get('flash'):
-            page_title = View.page_title_error_prefix_en + page_title
         locale = 'en'
-        self.log_entry(request, display_region + '/' + user_journey + '/' +
-                       valid_registration_types + '/start')
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/start')
 
         return {
             'display_region': display_region,
@@ -84,8 +80,6 @@ class RegisterConsent(View):
         display_region = request.match_info['display_region']
         request_type = request.match_info['request_type']
         page_title = 'Confirm consent'
-        if request.get('flash'):
-            page_title = View.page_title_error_prefix_en + page_title
         locale = 'en'
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/consent')
 
@@ -133,8 +127,6 @@ class RegisterConsentDeclined(View):
         display_region = request.match_info['display_region']
         request_type = request.match_info['request_type']
         page_title = 'You have been removed from this study'
-        if request.get('flash'):
-            page_title = View.page_title_error_prefix_en + page_title
         locale = 'en'
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/consent-declined')
 
@@ -174,10 +166,7 @@ class RegisterEnterMobile(View):
     async def post(self, request):
         display_region = request.match_info['display_region']
         request_type = request.match_info['request_type']
-        if display_region == 'cy':
-            locale = 'cy'
-        else:
-            locale = 'en'
+        locale = 'en'
 
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/enter-mobile')
 
@@ -227,7 +216,7 @@ class RegisterConfirmRegistration(View):
         session = await get_existing_session(request, user_journey, request_type)
         fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
 
-        page_title = 'Confirm to send access code by text'
+        page_title = 'Confirm your registration'
         if request.get('flash'):
             page_title = View.page_title_error_prefix_en + page_title
         locale = 'en'
@@ -244,7 +233,7 @@ class RegisterConfirmRegistration(View):
     async def post(self, request):
         display_region = request.match_info['display_region']
         request_type = request.match_info['request_type']
-        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/confirm-send-by-text')
+        self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/confirm-registration')
 
         session = await get_existing_session(request, user_journey, request_type)
         fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
@@ -255,10 +244,7 @@ class RegisterConfirmRegistration(View):
         except KeyError:
             logger.info('mobile confirmation error',
                         client_ip=request['client_ip'], client_id=request['client_id'], trace=request['trace'])
-            if display_region == 'cy':
-                flash(request, NO_SELECTION_CHECK_MSG_CY)
-            else:
-                flash(request, NO_SELECTION_CHECK_MSG)
+            flash(request, NO_SELECTION_CHECK_MSG)
             raise HTTPFound(
                 request.app.router['RegisterConfirmRegistration:get'].url_for(
                     display_region=display_region, request_type=request_type
@@ -286,10 +272,7 @@ class RegisterConfirmRegistration(View):
                         client_id=request['client_id'],
                         trace=request['trace'],
                         user_selection=mobile_confirmation)
-            if display_region == 'cy':
-                flash(request, NO_SELECTION_CHECK_MSG_CY)
-            else:
-                flash(request, NO_SELECTION_CHECK_MSG)
+            flash(request, NO_SELECTION_CHECK_MSG)
             raise HTTPFound(
                 request.app.router['RegisterConfirmRegistration:get'].url_for(display_region=display_region,
                                                                               request_type=request_type))
@@ -308,7 +291,7 @@ class RegisterComplete(View):
         session = await get_existing_session(request, user_journey, request_type)
         fulfilment_attributes = get_session_value(request, session, 'fulfilment_attributes', user_journey, request_type)
 
-        page_title = 'Access code has been sent by text'
+        page_title = 'Registration complete'
         locale = 'en'
 
         await invalidate(request)

--- a/app/register_handlers.py
+++ b/app/register_handlers.py
@@ -1,18 +1,16 @@
 import aiohttp_jinja2
 import json
 
-from aiohttp.client_exceptions import (ClientResponseError)
 from aiohttp.web import HTTPFound, RouteTableDef
 from structlog import get_logger
 
 from . import (NO_SELECTION_CHECK_MSG)
 
 from .flash import flash
-from .exceptions import TooManyRequestsRegister
 from .security import invalidate
 from .session import get_existing_session, get_session_value
 from .utils import View, ProcessMobileNumber, InvalidDataError, InvalidDataErrorWelsh, \
-    FlashMessage, ProcessName, ProcessDOB, RHService
+    FlashMessage, ProcessName, ProcessDOB
 
 logger = get_logger('respondent-home')
 register_routes = RouteTableDef()
@@ -419,11 +417,11 @@ class RegisterEnterChildName(View):
             'locale': locale,
             'request_type': request_type,
             'page_url': View.gen_page_url(request),
-            'first_name': get_session_value(request, register_attributes, 
+            'first_name': get_session_value(request, register_attributes,
                                             'child_first_name', user_journey, request_type),
             'middle_names': get_session_value(request, register_attributes,
                                               'child_middle_names', user_journey, request_type),
-            'last_name': get_session_value(request, register_attributes, 
+            'last_name': get_session_value(request, register_attributes,
                                            'child_last_name', user_journey, request_type)
         }
 
@@ -493,7 +491,7 @@ class RegisterSelectSchool(View):
 
         session = await get_existing_session(request, user_journey, request_type)
         register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
-        
+
         return {
             'display_region': display_region,
             'page_title': page_title,

--- a/app/register_handlers.py
+++ b/app/register_handlers.py
@@ -1,4 +1,5 @@
 import aiohttp_jinja2
+import json
 
 from aiohttp.client_exceptions import (ClientResponseError)
 from aiohttp.web import HTTPFound, RouteTableDef
@@ -35,6 +36,51 @@ class Register(View):
             'locale': locale,
             'page_url': View.gen_page_url(request),
             'request_type': 'person'
+        }
+
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/' + user_journey + '/sis/')
+class RegisterSIS(View):
+    @aiohttp_jinja2.template('register-sis2.html')
+    async def get(self, request):
+        display_region = 'en'
+        page_title = 'COVID-19 Schools Infection Survey (SIS)'
+        locale = 'en'
+        self.log_entry(request, display_region + '/' + user_journey + '/sis')
+
+        return {
+            'display_region': display_region,
+            'page_title': page_title,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+            'request_type': 'person'
+        }
+
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/' + user_journey + '/school-list/')
+class RegisterSchoolList(View):
+    @aiohttp_jinja2.template('register-school-list.html')
+    async def get(self, request):
+        display_region = 'en'
+        page_title = 'SIS school list'
+        locale = 'en'
+        self.log_entry(request, display_region + '/' + user_journey + '/school-list')
+
+        school_list = []
+        with open('app/data/schools.json') as file:
+            data = json.load(file)
+            for school in data:
+                school_list.append({
+                    'text': school['en']
+                })
+
+        return {
+            'display_region': display_region,
+            'page_title': page_title,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+            'request_type': 'person',
+            'school_list': school_list
         }
 
 
@@ -96,8 +142,7 @@ class RegisterEnterName(View):
 
         self.log_entry(request, display_region + '/' + user_journey + '/' + request_type + '/enter-name')
 
-        session = await get_existing_session(request, user_journey, request_type)
-        register_attributes = get_session_value(request, session, 'register_attributes', user_journey, request_type)
+        await get_existing_session(request, user_journey, request_type)
 
         return {
             'page_title': page_title,

--- a/app/register_handlers.py
+++ b/app/register_handlers.py
@@ -1,0 +1,27 @@
+import aiohttp_jinja2
+from aiohttp.web import RouteTableDef
+from structlog import get_logger
+
+from .utils import View
+
+logger = get_logger('respondent-home')
+register_routes = RouteTableDef()
+
+
+@register_routes.view(r'/' + View.valid_display_regions_en_only + '/register/')
+class Register(View):
+    @aiohttp_jinja2.template('register.html')
+    async def get(self, request):
+        display_region = 'en'
+        page_title = 'Take part in a survey'
+        if request.get('flash'):
+            page_title = View.page_title_error_prefix_en + page_title
+        locale = 'en'
+        self.log_entry(request, display_region + '/register')
+
+        return {
+            'display_region': display_region,
+            'page_title': page_title,
+            'locale': locale,
+            'page_url': View.gen_page_url(request),
+        }

--- a/app/routes.py
+++ b/app/routes.py
@@ -3,13 +3,14 @@ from aiohttp_utils.routing import add_resource_context
 from .web_form_handlers import web_form_routes
 from .request_handlers import request_routes
 from .start_handlers import start_routes
+from .register_handlers import register_routes
 from .handlers import static_routes
 
 
 def setup(app, url_path_prefix):
     """Set up routes as resources so we can use the `Index:get` notation for URL lookup."""
 
-    combined_routes = [*request_routes, *start_routes, *static_routes, *web_form_routes]
+    combined_routes = [*register_routes, *request_routes, *start_routes, *static_routes, *web_form_routes]
 
     for route in combined_routes:
         use_prefix = route.kwargs.get('use_prefix', True)

--- a/app/templates/base-en-register.html
+++ b/app/templates/base-en-register.html
@@ -1,0 +1,86 @@
+{%- extends 'layout/_template.njk' -%}
+
+{%- if page_title -%}
+    {%- set page_title_value = page_title + ' - ' + site_name_en -%}
+{%- else -%}
+    {%- set page_title_value = site_name_en -%}
+{%- endif -%}
+
+{%- set footer_content = {
+        'crest': true,
+        'rows': [
+            {
+                'itemsList': [
+                    {
+                        'text': 'Contact us',
+                        'url': domain_url_en + '/contact-us/'
+                    }
+                ]
+            }
+        ],
+        'legal': [
+            {
+                'itemsList': [
+                    {
+                        'text': 'Cookies',
+                        'url': domain_url_en + '/cookies/'
+                    },
+                    {
+                        'text': 'Accessibility statement',
+                        'url': domain_url_en + '/accessibility-statement/'
+                    },
+                    {
+                        'text': 'Privacy and data protection',
+                        'url': domain_url_en + '/privacy-and-data-protection/'
+                    },
+                    {
+                        'text': 'Terms and conditions',
+                        'url': domain_url_en + '/terms-and-conditions/'
+                    }
+                ]
+            }
+        ]
+    }
+-%}
+
+{%- set pageConfig = {
+    'title': page_title_value,
+    'header': {
+        'logoHref': 'https://www.ons.gov.uk/',
+        'title': site_name_en
+    },
+    'signoutButton': signout_button_value,
+    'footer': footer_content,
+    'cspNonce': cspNonce
+} -%}
+
+{%- block head -%}
+
+    <!-- Google Analytics -->
+    {%- if gtm_cont_id and gtm_auth -%}
+        {%- include 'partials/gtm.html' with context -%}
+    {%- endif -%}
+    <!-- End Google Analytics -->
+
+{%- endblock -%}
+
+{%- block bodyStart -%}
+
+    {%- if gtm_cont_id and gtm_auth -%}
+        {%- include 'partials/gtm-no-script.html' with context -%}
+    {%- endif -%}
+
+{%- endblock -%}
+
+{%- block preHeader -%}
+
+    {%- from 'components/cookies-banner/_macro.njk' import onsCookiesBanner -%}
+    {{
+        onsCookiesBanner({
+            "statementTitle": 'Tell us whether you accept cookies',
+            "statementText": 'We use <a href="' + domain_url_en + '/cookies' + '">cookies to collect information</a> about how you use surveys.ons.gov.uk. We use this information to make the website work as well as possible and improve our services.',
+            "confirmationText": 'You’ve accepted all cookies. You can <a href="' + domain_url_en + '/cookies' + '">change your cookie preferences</a> at any time.',
+            "secondaryButtonUrl": domain_url_en + '/cookies'
+        })
+    }}
+{%- endblock -%}

--- a/app/templates/launch-eq.html
+++ b/app/templates/launch-eq.html
@@ -29,7 +29,7 @@
 
     {{ onsButton({
         'text': _('Launch census'),
-        'classes': 'u-mb-xl',
+        'classes': 'ons-u-mb-xl',
         'name': 'action[save_continue]',
         'submitType': 'loader'
     }) }}

--- a/app/templates/register-child-dob.html
+++ b/app/templates/register-child-dob.html
@@ -1,0 +1,81 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- set messages_dict=dict(get_flashed_messages()|groupby('level')) -%}
+{%- set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) -%}
+
+{%- from 'components/question/_macro.njk' import onsQuestion -%}
+{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from "components/date-input/_macro.njk" import onsDateInput -%}
+
+{%- set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': ''
+    }
+} -%}
+
+{%- if 'dob_invalid' in field_messages_dict -%}
+    {%- set error = {'id': 'dob_invalid', 'text': _('Enter a valid date')} -%}
+{%- endif -%}
+
+{%- set child_name = first_name + ' ' + middle_names + ' ' + last_name -%}
+
+{%- block main -%}
+
+    {%- if messages_dict -%}
+        {%- include 'partials/messages.html' with context -%}
+    {%- endif -%}
+
+    {%- call onsQuestion({
+        'title': _('What is the date of birth of %(name)s?', name='%s' % child_name),
+    }) -%}
+
+        {{
+            onsDateInput({
+                "id": "date",
+                "legendOrLabel": "Date of birth",
+                "description": "For example, 31 3 1980",
+                "day": {
+                    "label": {
+                        "text": "Day"
+                    },
+                    "name": "day",
+                    "attributes": {
+                        "autocomplete": "bday-day"
+                    },
+                    "value": day
+                },
+                "month": {
+                    "label": {
+                        "text": "Month"
+                    },
+                    "name": "month",
+                    "attributes": {
+                        "autocomplete": "bday-month"
+                    },
+                    "value": month
+                },
+                "year": {
+                    "label": {
+                        "text": "Year"
+                    },
+                    "name": "year",
+                    "attributes": {
+                        "autocomplete": "bday-year"
+                    },
+                    "value": year
+                },
+                "error": error
+            })
+        }}
+
+    {%- endcall -%}
+
+    {{
+        onsButton({
+            'text': _('Continue'),
+            'classes': 'ons-u-mt-l'
+        })
+    }}
+
+{%- endblock -%}

--- a/app/templates/register-child-summary.html
+++ b/app/templates/register-child-summary.html
@@ -37,7 +37,7 @@
                                             {
                                                 "text": "Change",
                                                 "ariaLabel": "Change answer",
-                                                "url": url('RegisterEnterName:get', display_region=display_region, request_type=request_type)
+                                                "url": url('RegisterEnterChildName:get', display_region=display_region, request_type=request_type)
                                             }
                                         ]
                                     }

--- a/app/templates/register-complete.html
+++ b/app/templates/register-complete.html
@@ -15,7 +15,7 @@
     -%}
 
         {%- autoescape false -%}
-            <h1 class="u-mb-xs u-fs-l">{{ _('Your children have been registered for the survey') }} </h1>
+            <h1 class="u-mb-xs u-fs-l">{{ _('Your children have been registered for the survey') }}</h1>
         {%- endautoescape -%}
 
         <p>{{ _('A text message confirming your registration should arrive soon') }}</p>

--- a/app/templates/register-complete.html
+++ b/app/templates/register-complete.html
@@ -10,12 +10,12 @@
             'id': 'success-id',
             'icon': 'check',
             'iconSize': 'l',
-            'classes': 'u-mt-xl u-mb-m'
+            'classes': 'ons-u-mt-xl ons-u-mb-m'
         })
     -%}
 
         {%- autoescape false -%}
-            <h1 class="u-mb-xs u-fs-l">{{ _('Your children have been registered for the survey') }}</h1>
+            <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('Your children have been registered for the survey') }}</h1>
         {%- endautoescape -%}
 
         <p>{{ _('A text message confirming your registration should arrive soon') }}</p>
@@ -26,7 +26,7 @@
         call onsPanel({
             'type': 'bare',
             'icon': 'lock',
-            'classes': 'u-mb-l'
+            'classes': 'ons-u-mb-l'
         })
     -%}
 

--- a/app/templates/register-complete.html
+++ b/app/templates/register-complete.html
@@ -1,0 +1,37 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- from "components/panel/_macro.njk" import onsPanel -%}
+
+{%- block main -%}
+
+    {%-
+        call onsPanel({
+            'type': 'success',
+            'id': 'success-id',
+            'icon': 'check',
+            'iconSize': 'l',
+            'classes': 'u-mt-xl u-mb-m'
+        })
+    -%}
+
+        {%- autoescape false -%}
+            <h1 class="u-mb-xs u-fs-l">{{ _('Your children have been registered for the survey') }} </h1>
+        {%- endautoescape -%}
+
+        <p>{{ _('A text message confirming your registration should arrive soon') }}</p>
+
+    {%- endcall -%}
+
+    {%-
+        call onsPanel({
+            'type': 'bare',
+            'icon': 'lock',
+            'classes': 'u-mb-l'
+        })
+    -%}
+
+        <p>{{ _('The text will be sent from <strong>ONS</strong>') }}</p>
+
+    {%- endcall -%}
+
+{%- endblock -%}

--- a/app/templates/register-confirm-mobile.html
+++ b/app/templates/register-confirm-mobile.html
@@ -18,7 +18,7 @@
                 {
                     'id': 'yes',
                     'label': {
-                        'text': _('Yes, process my registration')
+                        'text': _('Yes, my mobile number is correct')
                     },
                     'value': 'yes'
                 },

--- a/app/templates/register-confirm-registration.html
+++ b/app/templates/register-confirm-registration.html
@@ -1,0 +1,70 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- set messages_dict=dict(get_flashed_messages()|groupby('level')) -%}
+{%- set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) -%}
+
+{%- from 'components/question/_macro.njk' import onsQuestion -%}
+{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from 'components/radios/_macro.njk' import onsRadios -%}
+
+{%- set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': ''
+    }
+} -%}
+
+{%- set form_options = [
+                {
+                    'id': 'yes',
+                    'label': {
+                        'text': _('Yes, process my registration')
+                    },
+                    'value': 'yes'
+                },
+                {
+                    'id': 'no',
+                    'label': {
+                        'text': _('No, I need to change it')
+                    },
+                    'value': 'no'
+                }
+            ]
+-%}
+
+{%- if 'no-selection' in field_messages_dict -%}
+    {%- set error_mobile = {'id': 'no-selection', 'text': _('Select an answer')} -%}
+{%- endif -%}
+
+{%- block main -%}
+
+    {%- if messages_dict -%}
+        {%- include 'partials/messages.html' with context -%}
+    {%- endif -%}
+
+    {%- call onsQuestion({
+        'title': _('Is this mobile number correct?'),
+        'description': '<p class="js-mobile-no">'|safe + submitted_mobile_number + '</p>'|safe
+    }) -%}
+
+        {{
+            onsRadios({
+                'name': 'request-mobile-confirmation',
+                'radios': form_options,
+                'legend': _('Is this mobile number correct?'),
+                'legendClasses': 'u-vh',
+                'error': error_mobile
+            })
+        }}
+
+    {%- endcall -%}
+
+    {{
+        onsButton({
+            'text': _('Continue'),
+            'classes': 'u-mt-l',
+            'submitType': 'loader'
+        })
+    }}
+
+{%- endblock -%}

--- a/app/templates/register-confirm-registration.html
+++ b/app/templates/register-confirm-registration.html
@@ -52,7 +52,7 @@
                 'name': 'request-mobile-confirmation',
                 'radios': form_options,
                 'legend': _('Is this mobile number correct?'),
-                'legendClasses': 'u-vh',
+                'legendClasses': 'ons-u-vh',
                 'error': error_mobile
             })
         }}
@@ -62,7 +62,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l',
+            'classes': 'ons-u-mt-l',
             'submitType': 'loader'
         })
     }}

--- a/app/templates/register-consent-declined.html
+++ b/app/templates/register-consent-declined.html
@@ -2,6 +2,6 @@
 
 {%- block main -%}
 
-    <h1 class="u-mb-xs u-fs-l">{{ _('You have been removed from this study') }}</h1>
+    <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('You have been removed from this study') }}</h1>
 
 {%- endblock main -%}

--- a/app/templates/register-consent-declined.html
+++ b/app/templates/register-consent-declined.html
@@ -1,0 +1,7 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- block main -%}
+
+    <h1 class="u-mb-xs u-fs-l">{{ _('You have been removed from this study') }}</h1>
+
+{%- endblock main -%}

--- a/app/templates/register-consent.html
+++ b/app/templates/register-consent.html
@@ -1,0 +1,64 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from "components/lists/_macro.njk" import onsList -%}
+
+{%- set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': ''
+    }
+} -%}
+
+{%- block main -%}
+
+    <h1 class="u-mb-xs u-fs-l">{{ _('Confirm consent') }}</h1>
+
+    {{
+        onsList({
+            'element': 'ol',
+            'itemsList': [
+                {
+                    'text': _('I confirm that I have read and understand the Information Sheet.')
+                },
+                {
+                    'text': _('I understand that my child’s participation is voluntary. I am free to withdraw my child from the study at any time without giving a reason and without my child’s care or education being affected.')
+                },
+                {
+                    'text': _('I have explained to my child what is involved in the study and my child is happy to participate.')
+                },
+                {
+                    'text': _('I understand that the results of the antibody test will/ won’t be reported back to me.')
+                },
+                {
+                    'text': _('I understand that information about other children and adults in my household will be collected in the questionnaire. and I have discussed this with my family.')
+                },
+                {
+                    'text': _('I understand that my information I provide will be shared within the study team which will include the Office for National Statistics (ONS), Public Health England (PHE), the London School of Hygiene and Tropical Medicine (LSHTM) and Department for Education (DfE).')
+                }
+            ]
+        })
+    }}
+
+    <div class="ons-btn-group">
+        {{
+            onsButton({
+                'type': 'input',
+                'text': _('I accept'),
+                'classes': 'btn-group__btn',
+                'value': 'accept',
+                'name': 'button-accept'
+            })
+        }}
+        {{
+            onsButton({
+                'type': 'input',
+                'text': _('I decline'),
+                'classes': 'btn-group__btn',
+                'value': 'decline',
+                'name': 'button-decline'
+            })
+        }}
+    </div>
+
+{%- endblock main -%}

--- a/app/templates/register-consent.html
+++ b/app/templates/register-consent.html
@@ -12,7 +12,7 @@
 
 {%- block main -%}
 
-    <h1 class="u-mb-xs u-fs-l">{{ _('Confirm consent') }}</h1>
+    <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('Confirm consent') }}</h1>
 
     {{
         onsList({

--- a/app/templates/register-enter-child-name.html
+++ b/app/templates/register-enter-child-name.html
@@ -17,12 +17,12 @@
 {%- if 'error_first_name_len' in field_messages_dict -%}
     {%- set error_first_name = {'id': 'error_first_name_len', 'text': _('You have entered too many characters. Enter up to 35 characters')} -%}
 {%- elif 'error_first_name' in field_messages_dict -%}
-    {%- set error_first_name = {'id': 'error_first_name', 'text': _('Enter your first name')} -%}
+    {%- set error_first_name = {'id': 'error_first_name', 'text': _("Enter your child's first name")} -%}
 {%- endif -%}
 {%- if 'error_last_name_len' in field_messages_dict -%}
     {%- set error_last_name = {'id': 'error_last_name_len', 'text': _('You have entered too many characters. Enter up to 35 characters')} -%}
 {%- elif 'error_last_name' in field_messages_dict -%}
-    {%- set error_last_name = {'id': 'error_last_name', 'text': _('Enter your last name')} -%}
+    {%- set error_last_name = {'id': 'error_last_name', 'text': _("Enter your child's last name")} -%}
 {%- endif -%}
 
 {% block main %}
@@ -32,7 +32,7 @@
     {% endif %}
 
     {% call onsQuestion({
-        'title': _("What is the parent/guardian's name?"),
+        'title': _('Who would you like to register?'),
     }) %}
 
 {%- if ('error_last_name' in field_messages_dict) or ('error_last_name_len' in field_messages_dict) -%}
@@ -158,7 +158,7 @@
 
     {{
         onsButton({
-            'text': _('Continue'),
+            'text': _('Save and continue'),
             'classes': 'ons-u-mt-l'
         })
     }}

--- a/app/templates/register-enter-mobile.html
+++ b/app/templates/register-enter-mobile.html
@@ -35,7 +35,7 @@
                 'id': 'telephone',
                 'type': 'tel',
                 'autocomplete': 'tel',
-                'classes': 'input--w-15',
+                'width': '15',
                 'label': {
                     'text': _('UK mobile number'),
                     'description': _('This will be stored and used to send study access codes')

--- a/app/templates/register-enter-mobile.html
+++ b/app/templates/register-enter-mobile.html
@@ -50,7 +50,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l'
+            'classes': 'ons-u-mt-l'
         })
     }}
 

--- a/app/templates/register-enter-mobile.html
+++ b/app/templates/register-enter-mobile.html
@@ -1,0 +1,57 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- set messages_dict=dict(get_flashed_messages()|groupby('level')) -%}
+{%- set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) -%}
+
+{%- from 'components/question/_macro.njk' import onsQuestion -%}
+{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from 'components/input/_macro.njk' import onsInput -%}
+
+{%- set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': ''
+    }
+} -%}
+
+{%- if 'mobile_empty' in field_messages_dict -%}
+    {%- set error_mobile = {'id': 'mobile_empty', 'text': _('Enter your mobile number')} -%}
+{%- elif 'mobile_invalid' in field_messages_dict -%}
+    {%- set error_mobile = {'id': 'mobile_invalid', 'text': _('Enter a UK mobile number in a valid format, for example, 07700 900345 or +44 7700 900345')} -%}
+{%- endif -%}
+
+{%- block main -%}
+
+    {%- if messages_dict -%}
+        {%- include 'partials/messages.html' with context -%}
+    {%- endif -%}
+
+    {%- call onsQuestion({
+        'title': _('What is your mobile number?'),
+    }) -%}
+
+        {{
+            onsInput({
+                'id': 'telephone',
+                'type': 'tel',
+                'autocomplete': 'tel',
+                'classes': 'input--w-15',
+                'label': {
+                    'text': _('UK mobile number'),
+                    'description': _('This will be stored and used to send study access codes')
+                },
+                'name': 'request-mobile-number',
+                'error': error_mobile
+            })
+        }}
+
+    {%- endcall -%}
+
+    {{
+        onsButton({
+            'text': _('Continue'),
+            'classes': 'u-mt-l'
+        })
+    }}
+
+{%- endblock -%}

--- a/app/templates/register-enter-name.html
+++ b/app/templates/register-enter-name.html
@@ -159,7 +159,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l'
+            'classes': 'ons-u-mt-l'
         })
     }}
 

--- a/app/templates/register-enter-name.html
+++ b/app/templates/register-enter-name.html
@@ -1,0 +1,166 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- set messages_dict=dict(get_flashed_messages()|groupby('level')) -%}
+{%- set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) -%}
+
+{%- from 'components/question/_macro.njk' import onsQuestion -%}
+{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from 'components/input/_macro.njk' import onsInput -%}
+
+{%- set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': ''
+    }
+} -%}
+
+{%- if 'error_first_name_len' in field_messages_dict -%}
+    {%- set error_first_name = {'id': 'error_first_name_len', 'text': _('You have entered too many characters. Enter up to 35 characters')} -%}
+{%- elif 'error_first_name' in field_messages_dict -%}
+    {%- set error_first_name = {'id': 'error_first_name', 'text': _('Enter your first name')} -%}
+{%- endif -%}
+{%- if 'error_last_name_len' in field_messages_dict -%}
+    {%- set error_last_name = {'id': 'error_last_name_len', 'text': _('You have entered too many characters. Enter up to 35 characters')} -%}
+{%- elif 'error_last_name' in field_messages_dict -%}
+    {%- set error_last_name = {'id': 'error_last_name', 'text': _('Enter your last name')} -%}
+{%- endif -%}
+
+{% block main %}
+
+    {% if messages_dict %}
+        {% include 'partials/messages.html' with context %}
+    {% endif %}
+
+    {% call onsQuestion({
+        'title': _('Who would you like to register?'),
+    }) %}
+
+{%- if ('error_last_name' in field_messages_dict) or ('error_last_name_len' in field_messages_dict) -%}
+    {%- if 'error_last_name_len' in field_messages_dict -%}
+        {%- set error_dict = field_messages_dict['error_last_name_len'] -%}
+    {%- else -%}
+        {%- set error_dict = field_messages_dict['error_last_name'] -%}
+    {%- endif -%}
+    {%- for fields in error_dict -%}
+
+        {{
+            onsInput({
+                'id': 'name_first_name',
+                'label': {
+                    'text': _('First name')
+                },
+                'value': fields.value_first_name,
+                'name': 'name_first_name',
+                'error': error_first_name,
+                'charCheckLimit': {
+                    'limit': 35,
+                    'charCountOverLimitSingular': _('{x} character too many'),
+                    'charCountOverLimitPlural': _('{x} characters too many'),
+                    'charCountSingular': _('You have {x} character remaining'),
+                    'charCountPlural': _('You have {x} characters remaining')
+                }
+            })
+        }}
+
+    {%- endfor -%}
+{%- else -%}
+
+        {{
+            onsInput({
+                'id': 'name_first_name',
+                'type': 'text',
+                'label': {
+                    'text': _('First name')
+                },
+                'value': first_name,
+                'name': 'name_first_name',
+                'error': error_first_name,
+                'charCheckLimit': {
+                    'limit': 35,
+                    'charCountOverLimitSingular': _('{x} character too many'),
+                    'charCountOverLimitPlural': _('{x} characters too many'),
+                    'charCountSingular': _('You have {x} character remaining'),
+                    'charCountPlural': _('You have {x} characters remaining')
+                }
+            })
+        }}
+
+{%- endif -%}
+
+        {{
+            onsInput({
+                'id': 'name_middle_names',
+                'type': 'text',
+                'label': {
+                    'text': _('Middle name(s)')
+                },
+                'value': middle_names,
+                'name': 'name_middle_names'
+            })
+        }}
+
+{%- if ('error_first_name' in field_messages_dict) or ('error_first_name_len' in field_messages_dict) -%}
+    {%- if 'error_first_name_len' in field_messages_dict -%}
+        {%- set error_dict = field_messages_dict['error_first_name_len'] -%}
+    {%- else -%}
+        {%- set error_dict = field_messages_dict['error_first_name'] -%}
+    {%- endif -%}
+    {%- for fields in error_dict -%}
+
+        {{
+            onsInput({
+                'id': 'name_last_name',
+                'label': {
+                    'text': _('Last name')
+                },
+                'value': fields.value_last_name,
+                'name': 'name_last_name',
+                'error': error_last_name,
+                'charCheckLimit': {
+                    'limit': 35,
+                    'charCountOverLimitSingular': _('{x} character too many'),
+                    'charCountOverLimitPlural': _('{x} characters too many'),
+                    'charCountSingular': _('You have {x} character remaining'),
+                    'charCountPlural': _('You have {x} characters remaining')
+                }
+            })
+        }}
+
+    {%- endfor -%}
+{%- else -%}
+
+        {{
+            onsInput({
+                'id': 'name_last_name',
+                'type': 'text',
+                'label': {
+                    'text': _('Last name')
+                },
+                'value': last_name,
+                'name': 'name_last_name',
+                'error': error_last_name,
+                'charCheckLimit': {
+                    'limit': 35,
+                    'charCountOverLimitSingular': _('{x} character too many'),
+                    'charCountOverLimitPlural': _('{x} characters too many'),
+                    'charCountSingular': _('You have {x} character remaining'),
+                    'charCountPlural': _('You have {x} characters remaining')
+                }
+            })
+        }}
+
+{%- endif -%}
+
+
+
+
+    {% endcall %}
+
+    {{
+        onsButton({
+            'text': _('Continue'),
+            'classes': 'u-mt-l'
+        })
+    }}
+
+{% endblock %}

--- a/app/templates/register-person-summary.html
+++ b/app/templates/register-person-summary.html
@@ -49,17 +49,19 @@
                                     {
                                         "valueList": [
                                             {
-                                                "text": "1 January 1981"
+                                                "text": child_dob
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": url('RegisterChildDOB:get', display_region=display_region, request_type=request_type)
                                             }
                                         ]
-                                    }
+                                    },
                                 ]
-                            }
-                        ]
-                    },
-                    {
-                        "groupTitle": "School details",
-                        "rows": [
+                            },
                             {
                                 "rowTitle": "What school does the child attend?",
                                 "rowItems": [
@@ -74,47 +76,6 @@
                                                 "text": "Change",
                                                 "ariaLabel": "Change answer",
                                                 "url": url('RegisterSelectSchool:get', display_region=display_region, request_type=request_type)
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "rowTitle": "What passports do you hold?",
-                                "rowItems": [
-                                    {
-                                        "valueList": [
-                                            {
-                                                "text": "United Kingdom"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "groupTitle": "Contact details",
-                        "rows": [
-                            {
-                                "rowTitle": "Have you completed an apprenticeship?",
-                                "rowItems": [
-                                    {
-                                        "valueList": [
-                                            {
-                                                "text": "Yes"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "rowTitle": "Have you achieved a GCSE or equivalent qualification?",
-                                "rowItems": [
-                                    {
-                                        "valueList": [
-                                            {
-                                                "text": "5 GCSEs grades A* to C or 9 to 4"
                                             }
                                         ]
                                     }

--- a/app/templates/register-person-summary.html
+++ b/app/templates/register-person-summary.html
@@ -12,7 +12,7 @@
 
 {%- block main -%}
 
-    <h1 class="u-mb-xs u-fs-l">{{ _('Check answers') }}</h1>
+    <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('Check answers') }}</h1>
 
 {{
     onsSummary({
@@ -61,12 +61,19 @@
                         "groupTitle": "School details",
                         "rows": [
                             {
-                                "rowTitle": "What is your country of birth?",
+                                "rowTitle": "What school does the child attend?",
                                 "rowItems": [
                                     {
                                         "valueList": [
                                             {
-                                                "text": "England"
+                                                "text": school_name
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": url('RegisterSelectSchool:get', display_region=display_region, request_type=request_type)
                                             }
                                         ]
                                     }
@@ -125,7 +132,7 @@
     {{
         onsButton({
             'text': _('Save and continue'),
-            'classes': 'u-mt-l'
+            'classes': 'ons-u-mt-l'
         })
     }}
 

--- a/app/templates/register-person-summary.html
+++ b/app/templates/register-person-summary.html
@@ -1,0 +1,132 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- from "components/summary/_macro.njk" import onsSummary -%}
+{%- from 'components/button/_macro.njk' import onsButton -%}
+
+{%- set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': ''
+    }
+} -%}
+
+{%- block main -%}
+
+    <h1 class="u-mb-xs u-fs-l">{{ _('Check answers') }}</h1>
+
+{{
+    onsSummary({
+        "summaries": [
+            {
+                "summaryTitle": first_name + ' ' + middle_names + ' ' + last_name,
+                "groups": [
+                    {
+                        "groupTitle": "Personal details",
+                        "headers":["Question", "Answer given", "Change answer"],
+                        "rows": [
+                            {
+                                "rowTitle": "Is the child's name " + first_name + " " + middle_names + " " + last_name + "?",
+                                "rowItems": [
+                                    {
+                                        "valueList": [
+                                            {
+                                                "text": "Yes it is"
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": url('RegisterEnterName:get', display_region=display_region, request_type=request_type)
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "rowTitle": "What's the child's date of birth?",
+                                "rowItems": [
+                                    {
+                                        "valueList": [
+                                            {
+                                                "text": "1 January 1981"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "groupTitle": "School details",
+                        "rows": [
+                            {
+                                "rowTitle": "What is your country of birth?",
+                                "rowItems": [
+                                    {
+                                        "valueList": [
+                                            {
+                                                "text": "England"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "rowTitle": "What passports do you hold?",
+                                "rowItems": [
+                                    {
+                                        "valueList": [
+                                            {
+                                                "text": "United Kingdom"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "groupTitle": "Contact details",
+                        "rows": [
+                            {
+                                "rowTitle": "Have you completed an apprenticeship?",
+                                "rowItems": [
+                                    {
+                                        "valueList": [
+                                            {
+                                                "text": "Yes"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "rowTitle": "Have you achieved a GCSE or equivalent qualification?",
+                                "rowItems": [
+                                    {
+                                        "valueList": [
+                                            {
+                                                "text": "5 GCSEs grades A* to C or 9 to 4"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    })
+}}
+
+
+    {{
+        onsButton({
+            'text': _('Save and continue'),
+            'classes': 'u-mt-l'
+        })
+    }}
+
+{%- endblock main -%}

--- a/app/templates/register-school-list.html
+++ b/app/templates/register-school-list.html
@@ -1,0 +1,17 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- from "components/lists/_macro.njk" import onsList -%}
+
+{%- block main -%}
+
+    <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('Schools taking part in SIS') }}</h1>
+
+    <p>The following schools are taking part in the survey. If your child's school is not listed, they will not be able to take part.</p>
+
+    {{
+        onsList({
+            "itemsList": school_list
+        })
+    }}
+
+{%- endblock main -%}

--- a/app/templates/register-select-school.html
+++ b/app/templates/register-select-school.html
@@ -1,0 +1,67 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- set messages_dict=dict(get_flashed_messages()|groupby('level')) -%}
+{%- set field_messages_dict=dict(messages_dict['ERROR']|groupby('field')) -%}
+
+{%- from 'components/question/_macro.njk' import onsQuestion -%}
+{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from "components/autosuggest/_macro.njk" import onsAutosuggest -%}
+
+{%- set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': ''
+    }
+} -%}
+
+{%- if 'error_selection' in field_messages_dict -%}
+    {%- set error_selection = {'id': 'error_selection', 'text': _('Enter a value')} -%}
+{%- endif -%}
+
+{%- set child_name = first_name + ' ' + middle_names + ' ' + last_name -%}
+
+{%- block main -%}
+
+    {%- if messages_dict -%}
+        {%- include 'partials/messages.html' with context -%}
+    {%- endif -%}
+
+    {%- call onsQuestion({
+        'title': _('What school does %(name)s attend?', name='%s' % child_name),
+    }) -%}
+
+        {{ onsAutosuggest({
+            "id": "school-name",
+            "label": {
+                "text": "School name",
+                "description": "Select from suggestions",
+                "id": "school-name-label"
+            },
+            "autocomplete": "off",
+            "instructions": "Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.",
+            "ariaYouHaveSelected": "You have selected",
+            "ariaMinChars": "Enter 3 or more characters for suggestions.",
+            "ariaResultsLabel": "Country suggestions",
+            "ariaOneResult": "There is one suggestion available.",
+            "ariaNResults": "There are {n} suggestions available.",
+            "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search",
+            "moreResults": "Continue entering to improve suggestions",
+            "resultsTitle": "Suggestions",
+            "autosuggestData": url('SchoolsData:get'),
+            "noResults": "No suggestions found. You can enter your own answer",
+            "typeMore": "Continue entering to get suggestions",
+            "name": "school-selection",
+            "value": school_name,
+            "error": error_selection
+        }) }}
+
+    {%- endcall -%}
+
+    {{
+        onsButton({
+            'text': _('Continue'),
+            'classes': 'ons-u-mt-l'
+        })
+    }}
+
+{%- endblock -%}

--- a/app/templates/register-select-school.html
+++ b/app/templates/register-select-school.html
@@ -6,6 +6,7 @@
 {%- from 'components/question/_macro.njk' import onsQuestion -%}
 {%- from 'components/button/_macro.njk' import onsButton -%}
 {%- from "components/autosuggest/_macro.njk" import onsAutosuggest -%}
+{%- from "components/panel/_macro.njk" import onsPanel -%}
 
 {%- set form =  {
     'method': 'POST',
@@ -56,6 +57,16 @@
         }) }}
 
     {%- endcall -%}
+
+    {%- call onsPanel({
+            "type": 'warn',
+            "classes": "ons-u-mt-xl"
+        })
+    -%}
+        <p>Not all schools are taking part. To see if your child's school is participating you can check on the <a href="{{ url('RegisterSchoolList:get', display_region=display_region, request_type='person') }}">list of schools taking part in SIS</a>.</p>
+    {%- endcall -%}
+
+
 
     {{
         onsButton({

--- a/app/templates/register-sis2.html
+++ b/app/templates/register-sis2.html
@@ -1,0 +1,40 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- from "components/content-pagination/_macro.njk" import onsContentPagination -%}
+
+{%- block main -%}
+
+    <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('COVID-19 Schools Infection Survey (SIS)') }}</h1>
+
+    <h2>How to take part</h2>
+
+    <p>To take part, you will need to complete an online consent and an enrolment questionnaire. Once this is submitted, you (student 16 years or over or school staff) or your child will be enrolled into the study.</p>
+
+    <p>Not all schools are taking part. To see if your child's school is participating you can check on the <a href="{{ url('RegisterSchoolList:get', display_region=display_region, request_type='person') }}">list of schools taking part in SIS</a>.</p>
+
+    <h2>About the study</h2>
+
+    <p>The coronavirus (COVID-19) pandemic is having a major impact across the UK.</p>
+
+    <p>We are inviting a sample of schools in England to take part in testing for coronavirus (COVID-19).</p>
+
+    <p>We need to assess the role of schools in coronavirus (COVID-19) transmission and how transmission within and from school settings can be minimised.</p>
+
+    <p>This study will find out how many school pupils and staff have had the COVID-19 infection, how many have already developed antibodies against the virus and how this changes over the course of the school year. The information we collect will help inform policies to protect school pupils and staff.</p>
+
+    <p>It is possible that some pupils and staff might be infected with the virus and not develop any symptoms.</p>
+
+    {{-
+      onsContentPagination({
+        "contentPaginationItems": [
+          {
+            "rel": 'next',
+            "text": 'Next',
+            "url": url('RegisterStart:get', display_region=display_region, request_type='person'),
+            "label": 'Register for the survey'
+          }
+        ]
+      })
+    }}
+
+{%- endblock main -%}

--- a/app/templates/register-start.html
+++ b/app/templates/register-start.html
@@ -2,16 +2,22 @@
 
 {%- from 'components/button/_macro.njk' import onsButton -%}
 
+{%- set form =  {
+    'method': 'POST',
+    'attributes': {
+        'action': ''
+    }
+} -%}
+
 {%- block main -%}
 
-    <h1 class="u-mb-xs u-fs-l">{{ _('Take part in a survey') }}</h1>
+    <h1 class="u-mb-xs u-fs-l">{{ _('Register a child') }}</h1>
 
     {{
         onsButton({
-            'type': 'button',
-            'text': _('How to register a child'),
+            'type': 'input',
+            'text': _('Start'),
             'classes': 'u-mb-m u-mt-m',
-            'url': url('RegisterStart:get', display_region=display_region, request_type=request_type)
         })
     }}
 

--- a/app/templates/register-start.html
+++ b/app/templates/register-start.html
@@ -1,5 +1,6 @@
 {%- extends 'base-' + display_region + '-register.html' -%}
 
+{%- from "components/lists/_macro.njk" import onsList -%}
 {%- from 'components/button/_macro.njk' import onsButton -%}
 
 {%- set form =  {
@@ -13,10 +14,34 @@
 
     <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('Register a child') }}</h1>
 
+    <p>To register for the survey, you will need to provide the following information:</p>
+
+    {{
+        onsList({
+            "itemsList": [
+                {
+                    "text": "parent or guardian's name"
+                },
+                {
+                    "text": "parent or guardian's mobile phone number"
+                },
+                {
+                    "text": "child's name"
+                },
+                {
+                    "text": "child's school"
+                },
+                {
+                    "text": "child's date of birth"
+                }
+            ]
+        })
+    }}
+
     {{
         onsButton({
             'type': 'input',
-            'text': _('Start'),
+            'text': _('Register now'),
             'classes': 'ons-u-mb-m ons-u-mt-m',
         })
     }}

--- a/app/templates/register-start.html
+++ b/app/templates/register-start.html
@@ -11,13 +11,13 @@
 
 {%- block main -%}
 
-    <h1 class="u-mb-xs u-fs-l">{{ _('Register a child') }}</h1>
+    <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('Register a child') }}</h1>
 
     {{
         onsButton({
             'type': 'input',
             'text': _('Start'),
-            'classes': 'u-mb-m u-mt-m',
+            'classes': 'ons-u-mb-m ons-u-mt-m',
         })
     }}
 

--- a/app/templates/register-timeout.html
+++ b/app/templates/register-timeout.html
@@ -1,0 +1,19 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- set register_url = url('Register:get', display_region=display_region) -%}
+{%- from 'components/panel/_macro.njk' import onsPanel -%}
+
+{%- block main -%}
+    <h1>{{ _('Sorry, you need to start again') }}</h1>
+
+    <p>{{ _('This is because you’ve either:') }}</p>
+    <ul>
+        <li>{{ _('been inactive for 45 minutes and your session has timed out to protect your information') }}</li>
+        <li>{{ _('followed a link to the middle of a registration request') }}</li>
+    </ul>
+
+    {% autoescape false %}
+        <p>{{ _('You need to start again to %(open)sregister%(close)s.', open='<a href="%s">' % register_url, close='</a>')|safe }}</p>
+    {% endautoescape %}
+
+{%- endblock -%}

--- a/app/templates/register-too-many-requests.html
+++ b/app/templates/register-too-many-requests.html
@@ -1,0 +1,12 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
+
+{%- block main -%}
+
+    <h1>{{ _('You have reached the maximum number of registrations you can make online') }}</h1>
+    {%- autoescape false -%}
+        <p>{{ _('If you need to register, please %(open)scontact us%(close)s', open='<a href="%s">' % contact_us_link, close='</a>')|safe }}</p>
+    {%- endautoescape -%}
+
+{%- endblock -%}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,18 @@
+{%- extends 'base-' + display_region + '-register.html' -%}
+
+{%- from 'components/button/_macro.njk' import onsButton -%}
+
+{%- block main -%}
+
+    <h1 class="u-mb-xs u-fs-l">Take part in a survey</h1>
+
+    {{
+        onsButton({
+            'type': 'button',
+            'text': _('How to register a child'),
+            'classes': 'u-mb-m u-mt-m',
+            'url': '#'
+        })
+    }}
+
+{%- endblock main -%}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -4,13 +4,13 @@
 
 {%- block main -%}
 
-    <h1 class="u-mb-xs u-fs-l">{{ _('Take part in a survey') }}</h1>
+    <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('Take part in a survey') }}</h1>
 
     {{
         onsButton({
             'type': 'button',
             'text': _('How to register a child'),
-            'classes': 'u-mb-m u-mt-m',
+            'classes': 'ons-u-mb-m ons-u-mt-m',
             'url': url('RegisterStart:get', display_region=display_region, request_type=request_type)
         })
     }}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,18 +1,23 @@
 {%- extends 'base-' + display_region + '-register.html' -%}
 
-{%- from 'components/button/_macro.njk' import onsButton -%}
+{%- from "components/card/_macro.njk" import onsCard -%}
 
 {%- block main -%}
 
     <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('Take part in a survey') }}</h1>
 
-    {{
-        onsButton({
-            'type': 'button',
-            'text': _('How to register a child'),
-            'classes': 'ons-u-mb-m ons-u-mt-m',
-            'url': url('RegisterStart:get', display_region=display_region, request_type=request_type)
-        })
-    }}
+    <div>
+        <div class="grid grid--column@xxs@s">
+            <div class="grid__col col-4@m">
+                {{ onsCard({
+                    "id": 'title1',
+                    "textId": 'text1',
+                    "title": 'COVID-19 Schools Infection Survey (SIS)',
+                    "url": url('RegisterSIS:get', display_region=display_region),
+                    "text": 'This survey assesses the role of schools in the coronavirus (COVID-19) transmission and how transmission within and from school settings can be minimised.'
+                }) }}
+            </div>
+        </div>
+    </div>
 
 {%- endblock main -%}

--- a/app/templates/request-code-confirm-address.html
+++ b/app/templates/request-code-confirm-address.html
@@ -59,7 +59,7 @@
                 'name': 'form-confirm-address',
                 'radios': form_options,
                 'legend': _('Is this the correct address?'),
-                'legendClasses': 'u-vh',
+                'legendClasses': 'ons-u-vh',
                 'error': error_address
             })
         }}
@@ -69,7 +69,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l',
+            'classes': 'ons-u-mt-l',
             'submitType': 'loader'
         })
     }}

--- a/app/templates/request-code-confirm-send-by-post.html
+++ b/app/templates/request-code-confirm-send-by-post.html
@@ -60,14 +60,14 @@
             {{ postcode }}
         </p>
 
-        <p class="u-mb-m"><a href="{{ request_common_enter_name_link }}">{{ _('Change name') }}</a></p>
+        <p class="ons-u-mb-m"><a href="{{ request_common_enter_name_link }}">{{ _('Change name') }}</a></p>
 
         {{
             onsRadios({
                 'name': 'request-name-address-confirmation',
                 'radios': form_options,
                 'legend': question_title,
-                'legendClasses': 'u-vh',
+                'legendClasses': 'ons-u-vh',
                 'error': error_radio
             })
         }}
@@ -77,7 +77,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l',
+            'classes': 'ons-u-mt-l',
             'submitType': 'loader'
         })
     }}

--- a/app/templates/request-code-confirm-send-by-text.html
+++ b/app/templates/request-code-confirm-send-by-text.html
@@ -52,7 +52,7 @@
                 'name': 'request-mobile-confirmation',
                 'radios': form_options,
                 'legend': _('Is this mobile number correct?'),
-                'legendClasses': 'u-vh',
+                'legendClasses': 'ons-u-vh',
                 'error': error_mobile
             })
         }}
@@ -62,7 +62,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l',
+            'classes': 'ons-u-mt-l',
             'submitType': 'loader'
         })
     }}

--- a/app/templates/request-code-enter-address.html
+++ b/app/templates/request-code-enter-address.html
@@ -55,7 +55,7 @@
             {{
                 onsButton({
                     'text': _('Continue'),
-                    'classes': 'u-mt-l',
+                    'classes': 'ons-u-mt-l',
                     'submitType': 'loader'
                 })
             }}
@@ -110,7 +110,7 @@
             {{
                 onsButton({
                     'text': _('Continue'),
-                    'classes': 'u-mt-l',
+                    'classes': 'ons-u-mt-l',
                     'submitType': 'timer'
                 })
             }}

--- a/app/templates/request-code-enter-mobile.html
+++ b/app/templates/request-code-enter-mobile.html
@@ -35,7 +35,7 @@
                 'id': 'telephone',
                 'type': 'tel',
                 'autocomplete': 'tel',
-                'classes': 'input--w-15',
+                'width': '15',
                 'label': {
                     'text': _('UK mobile number'),
                     'description': _('This will not be stored and only used once to send the access code')

--- a/app/templates/request-code-enter-mobile.html
+++ b/app/templates/request-code-enter-mobile.html
@@ -50,7 +50,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l'
+            'classes': 'ons-u-mt-l'
         })
     }}
 

--- a/app/templates/request-code-enter-name.html
+++ b/app/templates/request-code-enter-name.html
@@ -150,7 +150,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l'
+            'classes': 'ons-u-mt-l'
         })
     }}
 

--- a/app/templates/request-code-select-address.html
+++ b/app/templates/request-code-select-address.html
@@ -15,9 +15,9 @@
 } %}
 
 {%- if total_matches == 1: -%}
-    {%- set question_description = _('<p class="u-fs-r--b">%(total)s address found for postcode %(pcode)s</p>', total=total_matches|string, pcode=postcode) -%}
+    {%- set question_description = _('<p class="ons-u-fs-r--b">%(total)s address found for postcode %(pcode)s</p>', total=total_matches|string, pcode=postcode) -%}
 {%- else: -%}
-    {%- set question_description = _('<p class="u-fs-r--b">%(total)s addresses found for postcode %(pcode)s</p>', total=total_matches|string, pcode=postcode) -%}
+    {%- set question_description = _('<p class="ons-u-fs-r--b">%(total)s addresses found for postcode %(pcode)s</p>', total=total_matches|string, pcode=postcode) -%}
 {%- endif -%}
 
 {%- if 'error-no-address-selected' in field_messages_dict -%}
@@ -53,7 +53,7 @@
                     'or': _('Or'),
                     'radios': addresses,
                     'legend': _('Select your address'),
-                    'legendClasses': 'u-vh',
+                    'legendClasses': 'ons-u-vh',
                     'error': error_select_address
                 })
             }}
@@ -63,7 +63,7 @@
         {{
             onsButton({
                 'text': _('Continue'),
-                'classes': 'u-mt-l',
+                'classes': 'ons-u-mt-l',
                 'submitType': 'loader'
             })
         }}

--- a/app/templates/request-code-select-how-to-receive.html
+++ b/app/templates/request-code-select-how-to-receive.html
@@ -66,7 +66,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-xl u-mb-xl'
+            'classes': 'ons-u-mt-xl ons-u-mb-xl'
         })
     }}
 

--- a/app/templates/request-code-sent-by-post.html
+++ b/app/templates/request-code-sent-by-post.html
@@ -22,11 +22,11 @@
             'id': 'success-id',
             'icon': 'check',
             'iconSize': 'l',
-            'classes': 'u-mt-xl'
+            'classes': 'ons-u-mt-xl'
         })
     -%}
 
-        <h1 class="u-mb-xs u-fs-l">{{ _('A letter will be sent to %(name)s at %(address)s', name=display_name, address=display_address)|safe }} </h1>
+        <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('A letter will be sent to %(name)s at %(address)s', name=display_name, address=display_address)|safe }} </h1>
 
         <p>{{ _('The letter with a new access code for you to start the study should arrive within 5 working days') }}</p>
 
@@ -36,7 +36,7 @@
         onsButton({
             'type': 'button',
             'text': _('Done'),
-            'classes': 'u-mt-xl',
+            'classes': 'ons-u-mt-xl',
             'url': census_home_link
         })
     }}

--- a/app/templates/request-code-sent-by-text.html
+++ b/app/templates/request-code-sent-by-text.html
@@ -14,12 +14,12 @@
             'id': 'success-id',
             'icon': 'check',
             'iconSize': 'l',
-            'classes': 'u-mt-xl u-mb-m'
+            'classes': 'ons-u-mt-xl ons-u-mb-m'
         })
     -%}
 
         {%- autoescape false -%}
-            <h1 class="u-mb-xs u-fs-l">{{ _('A text has been sent to %(number)s', number=submitted_mobile_number|replace(" ", "&nbsp;"))|safe }} </h1>
+            <h1 class="ons-u-mb-xs ons-u-fs-l">{{ _('A text has been sent to %(number)s', number=submitted_mobile_number|replace(" ", "&nbsp;"))|safe }} </h1>
         {%- endautoescape -%}
 
         <p>{{ _('The text message with a new access code should arrive soon for you to start your study') }}</p>
@@ -30,7 +30,7 @@
         call onsPanel({
             'type': 'bare',
             'icon': 'lock',
-            'classes': 'u-mb-l'
+            'classes': 'ons-u-mb-l'
         })
     -%}
 
@@ -38,19 +38,19 @@
 
     {%- endcall -%}
 
-    <h2 class="u-fs-m u-mb-xs">{{ _("Didn’t receive a text?") }}</h2>
+    <h2 class="ons-u-fs-m ons-u-mb-xs">{{ _("Didn’t receive a text?") }}</h2>
 
     {%- autoescape false -%}
-        <p class="u-mb-l">{{ _("It can take a few minutes for the text to arrive. If it doesn’t arrive, you can %(open)srequest a new access code%(close)s.", open='<a href="%s">' % request_code_link, close='</a>')|safe }}</p>
+        <p class="ons-u-mb-l">{{ _("It can take a few minutes for the text to arrive. If it doesn’t arrive, you can %(open)srequest a new access code%(close)s.", open='<a href="%s">' % request_code_link, close='</a>')|safe }}</p>
     {%- endautoescape -%}
 
-    <h2 class="u-mb-s u-fs-m">{{ _("Ready to start your study?") }}</h2>
+    <h2 class="ons-u-mb-s ons-u-fs-m">{{ _("Ready to start your study?") }}</h2>
 
     {{
         onsButton({
             'type': 'button',
             'text': _('Start study'),
-            'classes': 'u-mb-m',
+            'classes': 'ons-u-mb-m',
             'url': start_study_link
         })
     }}

--- a/app/templates/request-contact-centre.html
+++ b/app/templates/request-contact-centre.html
@@ -2,7 +2,7 @@
 
 {%- block main -%}
 
-    <h1 class="u-mt-l">{{ _('You need to call the customer contact centre') }}</h1>
+    <h1 class="ons-u-mt-l">{{ _('You need to call the customer contact centre') }}</h1>
 
     {%- if issue == 'address-not-required' -%}
         <p>The address you have selected is not required for this survey. If you believe this to be incorrect you will need to contact us.</p>

--- a/app/templates/signed-out.html
+++ b/app/templates/signed-out.html
@@ -15,7 +15,7 @@
         })
     -%}
 
-        <h1 class="u-mb-xs u-fs-xl">
+        <h1 class="ons-u-mb-xs ons-u-fs-xl">
             {{ _('Your progress has been saved') }}
         </h1>
 

--- a/app/templates/start-confirm-address.html
+++ b/app/templates/start-confirm-address.html
@@ -59,7 +59,7 @@
             'name': 'address-check-answer',
             'radios': form_radio_options,
             'legend': _('Is this the correct address?'),
-            'legendClasses': 'u-vh',
+            'legendClasses': 'ons-u-vh',
             'error': error_address
         })
     }}
@@ -69,7 +69,7 @@
     {{
         onsButton({
             'text': _('Continue'),
-            'classes': 'u-mt-l',
+            'classes': 'ons-u-mt-l',
             'name': 'action[save_continue]',
             'submitType': 'loader'
         })

--- a/app/templates/start-incorrect-address.html
+++ b/app/templates/start-incorrect-address.html
@@ -2,7 +2,7 @@
 
 {%- block main -%}
 
-    <h1 class="u-mt-l">{{ _('You do not need to take part in this study') }}</h1>
+    <h1 class="ons-u-mt-l">{{ _('You do not need to take part in this study') }}</h1>
 
     <p>We do not need you to complete a study at this time.</p>
 

--- a/app/templates/start-too-many-requests.html
+++ b/app/templates/start-too-many-requests.html
@@ -53,7 +53,7 @@
 
     <hr>
 
-    <h2 class="u-fs-m u-mt-l">{{_("Why it's important you take part in the census")}}</h2>
+    <h2 class="ons-u-fs-m ons-u-mt-l">{{_("Why it's important you take part in the census")}}</h2>
 
     <p>{{ _('Taking part in the census is your chance to help make sure you and your community get the services you need for the next 10 years and beyond.') }}</p>
 

--- a/app/templates/start.html
+++ b/app/templates/start.html
@@ -61,7 +61,7 @@
         {% include 'partials/messages.html' with context %}
     {% endif %}
 
-    <h1 class="u-fs-xxl u-mt-l">{{_('Start study')}}</h1>
+    <h1 class="ons-u-fs-xxl ons-u-mt-l">{{_('Start study')}}</h1>
 
     {{
         onsUACInput({
@@ -80,7 +80,7 @@
 
     {{ onsButton({
         'text': _('Access survey'),
-        'classes': 'u-mb-xl',
+        'classes': 'ons-u-mb-xl',
         'name': 'action[save_continue]',
         'submitType': 'loader'
     }) }}

--- a/app/templates/web-form-success.html
+++ b/app/templates/web-form-success.html
@@ -41,7 +41,7 @@
 {%- block main -%}
 
     {%- set panel_content -%}
-        <h1 class="u-fs-xxl">{{ _('Thank you for contacting us') }}</h1>
+        <h1 class="ons-u-fs-xxl">{{ _('Thank you for contacting us') }}</h1>
         <p>{{ _('Your message has been sent') }}</p>
     {%- endset -%}
 
@@ -51,7 +51,7 @@
             'id': 'success-id',
             'icon': 'check',
             'body': panel_content|safe,
-            'classes': 'u-mb-m'
+            'classes': 'ons-u-mb-m'
         })
     }}
 

--- a/app/templates/web-form.html
+++ b/app/templates/web-form.html
@@ -130,7 +130,7 @@
         {%- include 'partials/messages.html' with context -%}
     {%- endif -%}
 
-    <h1 class="u-fs-xxl u-mt-l">{{_('Web form')}}</h1>
+    <h1 class="ons-u-fs-xxl ons-u-mt-l">{{_('Web form')}}</h1>
 
     {{
         onsRadios({
@@ -173,7 +173,7 @@
         })
     }}
 
-    <h2 class="u-mt-m">{{ _('Your contact details') }}</h2>
+    <h2 class="ons-u-mt-m">{{ _('Your contact details') }}</h2>
 
     {{
         onsInput({
@@ -209,14 +209,14 @@
     {{
         onsButton({
             'text': _('Send message'),
-            'classes': 'btn-group__btn u-mb-m u-mt-m',
+            'classes': 'btn-group__btn ons-u-mb-m ons-u-mt-m',
             'submitType': 'loader'
         })
 
     }}
 
     {%- autoescape false -%}
-        <p class="u-fs-s">{{ _('Information about what we do with your personal data is available in our %(open)sprivacy and data protection statement%(close)s.', open='<a href="%s">' % privacy_link, close='</a>')|safe }}</p>
+        <p class="ons-u-fs-s">{{ _('Information about what we do with your personal data is available in our %(open)sprivacy and data protection statement%(close)s.', open='<a href="%s">' % privacy_link, close='</a>')|safe }}</p>
     {%- endautoescape -%}
 
 {%- endblock -%}

--- a/app/utils.py
+++ b/app/utils.py
@@ -327,6 +327,26 @@ class ProcessName:
         return name_valid
 
 
+class ProcessDOB:
+    @staticmethod
+    def validate_dob(data):
+        form_day = data.get('day')
+        form_month = data.get('month')
+        form_year = data.get('year')
+
+        try:
+            date = datetime(int(form_year), int(form_month), int(form_day)).date()
+            return date
+        except ValueError:
+            raise InvalidDataError('invalid dob', message_type='invalid')
+
+    @staticmethod
+    def format_dob(date_value):
+        unformatted_date = datetime.strptime(date_value, '%Y-%m-%d')
+        formatted_date = unformatted_date.strftime('%d %B %Y')
+        return formatted_date
+
+
 class FlashMessage:
 
     @staticmethod

--- a/app/utils.py
+++ b/app/utils.py
@@ -274,21 +274,26 @@ class ProcessMobileNumber:
 class ProcessName:
 
     @staticmethod
-    def validate_name(request, data, display_region):
+    def validate_name(request, data, display_region, child=False):
 
         name_valid = True
         form_first_name = data.get('name_first_name')
         form_last_name = data.get('name_last_name')
 
         if (not form_first_name) or (len(form_first_name.strip()) == 0):
-            if display_region == 'cy':
-                flash(request, {'text': "Rhowch eich enw cyntaf", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
+            if child:
+                flash(request, {'text': "Enter your child's first name", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
                                 'field': 'error_first_name', 'value_first_name': form_first_name,
                                 'value_last_name': form_last_name})
             else:
-                flash(request, {'text': "Enter your first name", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
-                                'field': 'error_first_name', 'value_first_name': form_first_name,
-                                'value_last_name': form_last_name})
+                if display_region == 'cy':
+                    flash(request, {'text': "Rhowch eich enw cyntaf", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
+                                    'field': 'error_first_name', 'value_first_name': form_first_name,
+                                    'value_last_name': form_last_name})
+                else:
+                    flash(request, {'text': "Enter your first name", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
+                                    'field': 'error_first_name', 'value_first_name': form_first_name,
+                                    'value_last_name': form_last_name})
             name_valid = False
 
         elif len(form_first_name) > 35:
@@ -303,14 +308,19 @@ class ProcessName:
             name_valid = False
 
         if (not form_last_name) or (len(form_last_name.strip()) == 0):
-            if display_region == 'cy':
-                flash(request, {'text': "Rhowch eich cyfenw", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
+            if child:
+                flash(request, {'text': "Enter your child's last name", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
                                 'field': 'error_last_name', 'value_first_name': form_first_name,
                                 'value_last_name': form_last_name})
             else:
-                flash(request, {'text': "Enter your last name", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
-                                'field': 'error_last_name', 'value_first_name': form_first_name,
-                                'value_last_name': form_last_name})
+                if display_region == 'cy':
+                    flash(request, {'text': "Rhowch eich cyfenw", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
+                                    'field': 'error_last_name', 'value_first_name': form_first_name,
+                                    'value_last_name': form_last_name})
+                else:
+                    flash(request, {'text': "Enter your last name", 'level': 'ERROR', 'type': 'NAME_ENTER_ERROR',
+                                    'field': 'error_last_name', 'value_first_name': form_first_name,
+                                    'value_last_name': form_last_name})
             name_valid = False
 
         elif len(form_last_name) > 35:

--- a/app/utils.py
+++ b/app/utils.py
@@ -32,6 +32,7 @@ uk_zone = timezone('Europe/London')
 
 class View:
     valid_display_regions = r'{display_region:\ben|cy\b}'
+    valid_display_regions_en_only = r'{display_region:\ben\b}'
     valid_user_journeys = r'{user_journey:\bstart|request\b}'
     page_title_error_prefix_en = 'Error: '
     page_title_error_prefix_cy = 'Gwall: '

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="39.1.0"
+DESIGN_SYSTEM_VERSION="40.0.1"
 
 TEMP_DIR=$(mktemp -d)
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1003,6 +1003,9 @@ class RHTestCase(AioHTTPTestCase):
         self.content_web_form_error_429_title_en = 'You have reached the maximum number web form submissions'
         self.content_web_form_error_429_title_cy = "Allwch chi ddim cyflwyno mwy o ffurflenni gwe"
 
+        # Start Register
+        self.get_register_en = self.app.router['Register:get'].url_for(display_region='en')
+
         # yapf: enable
 
     # URL functions

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -290,7 +290,7 @@ class RHTestCase(AioHTTPTestCase):
         :param title: str
         :param content: rendered HTML str
         """
-        self.assertIn('<h1 id="question-title" class="question__title">' + title + '</h1>', content)
+        self.assertIn('<h1 id="question-title" class="ons-question__title">' + title + '</h1>', content)
 
     def assertCorrectPageTitle(self, title, content):
         """
@@ -298,7 +298,7 @@ class RHTestCase(AioHTTPTestCase):
         :param title: str
         :param content: rendered HTML str
         """
-        self.assertIn('<h1 class="u-mb-xs u-fs-l">' + title + '</h1>', content)
+        self.assertIn('<h1 class="ons-u-mb-xs ons-u-fs-l">' + title + '</h1>', content)
 
     def assertErrorMessageDisplayed(self, display_region, panel_label, list_error, field_name, field_error, content):
         """
@@ -321,9 +321,9 @@ class RHTestCase(AioHTTPTestCase):
             else:
                 panel_label_text = 'There is a problem with this page'
 
-        self.assertIn('<h2 id="error-summary-title" data-qa="error-header" class="panel__title u-fs-r--b">'
+        self.assertIn('<h2 id="error-summary-title" data-qa="error-header" class="ons-panel__title ons-u-fs-r--b">'
                       + panel_label_text + '</h2>', content)
-        self.assertIn('<a href="#' + field_name + '" class="list__link js-inpagelink">' + list_error + '</a>',
+        self.assertIn('<a href="#' + field_name + '" class="ons-list__link  js-inpagelink">' + list_error + '</a>',
                       content)
         self.assertIn('<strong>' + field_error + '</strong>', content)
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1097,7 +1097,7 @@ class TestHelpers(RHTestCase):
         else:
             self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=False)
 
-        self.assertIn('<h1 class="u-fs-xxl u-mt-l">' + h1_title + '</h1>', contents)
+        self.assertIn('<h1 class="ons-u-fs-xxl ons-u-mt-l">' + h1_title + '</h1>', contents)
         self.assertIn(secondary_text, contents)
         self.assertEqual(contents.count('input--text'), 1)
         self.assertIn('type="submit"', contents)

--- a/tests/unit/test_register_handlers.py
+++ b/tests/unit/test_register_handlers.py
@@ -63,6 +63,23 @@ class TestRegisterHandlers(TestHelpers):
             self.assertIn('Titchfield Primary School, Hampshire', contents)
         self.assertIn('Select from suggestions', contents)
 
+    def check_content_register_child_dob(self, display_region, contents, error=False, change=False):
+        if error:
+            error_text = 'Enter a valid date'
+            self.assertErrorMessageDisplayed(display_region, 'answer', error_text, 'dob_invalid',
+                                             error_text, contents)
+            self.assertCorrectHeadTitleTag(display_region, 'Enter date of birth', contents, error=True)
+        else:
+            self.assertCorrectHeadTitleTag(display_region, 'Enter date of birth', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectQuestionText('What is the date of birth of Belinda Olivia Bobbington?', contents)
+        if change:
+            self.assertIn('value="9"', contents)
+            self.assertIn('value="10"', contents)
+            self.assertIn('value="2011"', contents)
+        self.assertIn('For example, 31 3 1980', contents)
+
     def check_content_register_person_summary(self, display_region, contents, change=None):
         self.assertCorrectHeadTitleTag(display_region, 'Person summary', contents, error=False)
         self.assertSiteLogo(display_region, contents)
@@ -76,9 +93,11 @@ class TestRegisterHandlers(TestHelpers):
             self.assertIn('Four Marks Church of England Primary School, Hampshire', contents)
         else:
             self.assertIn('Titchfield Primary School, Hampshire', contents)
+        if change == 'dob':
+            self.assertIn('11 December 2013', contents)
+        else:
+            self.assertIn('9 October 2011', contents)
         self.assertIn('<h3 class="ons-summary__group-title">Personal details</h3>', contents)
-        self.assertIn('<h3 class="ons-summary__group-title">School details</h3>', contents)
-        self.assertIn('<h3 class="ons-summary__group-title">Contact details</h3>', contents)
 
     def check_content_register_consent(self, display_region, contents):
         self.assertCorrectHeadTitleTag(display_region, 'Confirm consent', contents, error=False)
@@ -144,7 +163,7 @@ class TestRegisterHandlers(TestHelpers):
             get_response = await self.client.request('GET', url_get)
             self.assertLogEvent(cm, self.build_url_log_entry('', display_region, 'GET',
                                                              include_request_type=False, include_page=False))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register(display_region, str(await get_response.content.read()))
 
     async def get_register_start(self, display_region):
@@ -153,7 +172,7 @@ class TestRegisterHandlers(TestHelpers):
             get_response = await self.client.request('GET', url_get)
             self.assertLogEvent(cm, self.build_url_log_entry('start', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_start(display_region, str(await get_response.content.read()))
 
     async def post_register_start(self, display_region):
@@ -165,7 +184,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_enter_name(display_region, str(await get_response.content.read()))
 
     async def post_register_enter_name_valid(self, display_region):
@@ -179,7 +198,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('select-school', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_select_school(display_region, str(await get_response.content.read()))
 
     async def post_register_enter_name_invalid_first(self, display_region):
@@ -193,7 +212,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_enter_name(display_region, str(await get_response.content.read()),
                                                    error='first_name')
 
@@ -208,7 +227,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_enter_name(display_region, str(await get_response.content.read()),
                                                    error='last_name')
 
@@ -223,7 +242,7 @@ class TestRegisterHandlers(TestHelpers):
             get_response = await self.client.request('GET', url_get)
             self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_enter_name(display_region, str(await get_response.content.read()),
                                                    change=True)
             post_response = await self.client.request('POST', url_post, data=data)
@@ -231,7 +250,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, post_response.status)
             self.check_content_register_person_summary(display_region, str(await post_response.content.read()),
                                                        change='name')
 
@@ -243,10 +262,10 @@ class TestRegisterHandlers(TestHelpers):
             get_response = await self.client.request('POST', url_post, data=data)
             self.assertLogEvent(cm, self.build_url_log_entry('select-school', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('child-dob', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
-            self.check_content_register_person_summary(display_region, str(await get_response.content.read()))
+            self.assertEqual(200, get_response.status)
+            self.check_content_register_child_dob(display_region, str(await get_response.content.read()))
 
     async def post_register_select_school_empty(self, display_region):
         url_post = self.get_url_from_class('RegisterSelectSchool', 'post',
@@ -258,7 +277,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('select-school', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(post_response.status, 200)
+            self.assertEqual(200, post_response.status)
             self.check_content_register_select_school(display_region, str(await post_response.content.read()),
                                                       error=True)
 
@@ -273,7 +292,7 @@ class TestRegisterHandlers(TestHelpers):
             get_response = await self.client.request('GET', url_get)
             self.assertLogEvent(cm, self.build_url_log_entry('select-school', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_select_school(display_region, str(await get_response.content.read()),
                                                       change=True)
             post_response = await self.client.request('POST', url_post, data=data)
@@ -281,9 +300,58 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, post_response.status)
             self.check_content_register_person_summary(display_region, str(await post_response.content.read()),
                                                        change='school')
+
+    async def post_register_child_dob(self, display_region):
+        url_post = self.get_url_from_class('RegisterChildDOB', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'day': '9', 'month': '10', 'year': '2011', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('child-dob', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(200, get_response.status)
+            self.check_content_register_person_summary(display_region, str(await get_response.content.read()))
+
+    async def post_register_child_dob_empty(self, display_region):
+        url_post = self.get_url_from_class('RegisterChildDOB', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'day': '', 'month': '', 'year': '', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            post_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('child-dob', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('child-dob', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(200, post_response.status)
+            self.check_content_register_child_dob(display_region, str(await post_response.content.read()),
+                                                  error=True)
+
+    async def process_register_child_dob_change(self, display_region):
+        url_get = self.get_url_from_class('RegisterChildDOB', 'get',
+                                          display_region=display_region, request_type='person')
+        url_post = self.get_url_from_class('RegisterChildDOB', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'day': '11', 'month': '12', 'year': '2013', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('GET', url_get)
+            self.assertLogEvent(cm, self.build_url_log_entry('child-dob', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(200, get_response.status)
+            self.check_content_register_child_dob(display_region, str(await get_response.content.read()),
+                                                  change=True)
+            post_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('child-dob', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(200, post_response.status)
+            self.check_content_register_person_summary(display_region, str(await post_response.content.read()),
+                                                       change='dob')
 
     async def post_register_person_summary(self, display_region):
         url_post = self.get_url_from_class('RegisterPersonSummary', 'post',
@@ -294,7 +362,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_consent(display_region, str(await get_response.content.read()))
 
     async def post_register_consent_accept(self, display_region):
@@ -307,7 +375,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()))
 
     async def post_register_consent_declined(self, display_region):
@@ -320,7 +388,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('consent-declined', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_consent_declined(display_region, str(await get_response.content.read()))
 
     async def post_register_consent_invalid(self, display_region):
@@ -333,7 +401,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_consent(display_region, str(await get_response.content.read()))
 
     async def post_register_enter_mobile_valid(self, display_region):
@@ -347,7 +415,7 @@ class TestRegisterHandlers(TestHelpers):
             self.assertLogEvent(cm, 'valid mobile number')
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()))
 
     async def post_register_enter_mobile_empty(self, display_region):
@@ -360,7 +428,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()),
                                                      error='empty')
 
@@ -374,7 +442,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()),
                                                      error='invalid')
 
@@ -388,7 +456,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('complete', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_complete(display_region, str(await get_response.content.read()))
 
     async def post_register_confirm_registration_no(self, display_region):
@@ -401,7 +469,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()))
 
     async def post_register_confirm_registration_missing(self, display_region):
@@ -414,7 +482,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()),
                                                              error='empty')
 
@@ -428,7 +496,7 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
-            self.assertEqual(get_response.status, 200)
+            self.assertEqual(200, get_response.status)
             self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()),
                                                              error='invalid')
 
@@ -440,6 +508,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.post_register_consent_accept(display_region)
         await self.post_register_enter_mobile_valid(display_region)
@@ -452,6 +521,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.process_register_name_change(display_region)
 
@@ -484,8 +554,29 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.process_register_school_change(display_region)
+
+    @unittest_run_loop
+    async def test_register_child_dob_empty_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_enter_name_valid(display_region)
+        await self.post_register_select_school(display_region)
+        await self.post_register_child_dob_empty(display_region)
+
+    @unittest_run_loop
+    async def test_register_child_dob_change_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_enter_name_valid(display_region)
+        await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
+        await self.post_register_person_summary(display_region)
+        await self.process_register_child_dob_change(display_region)
 
     @unittest_run_loop
     async def test_register_consent_declined_en(self):
@@ -494,6 +585,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.post_register_consent_declined(display_region)
 
@@ -504,6 +596,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.post_register_consent_invalid(display_region)
 
@@ -514,6 +607,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.post_register_consent_accept(display_region)
         await self.post_register_enter_mobile_empty(display_region)
@@ -525,6 +619,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.post_register_consent_accept(display_region)
         await self.post_register_enter_mobile_invalid(display_region)
@@ -536,6 +631,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.post_register_consent_accept(display_region)
         await self.post_register_enter_mobile_valid(display_region)
@@ -548,6 +644,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.post_register_consent_accept(display_region)
         await self.post_register_enter_mobile_valid(display_region)
@@ -560,6 +657,7 @@ class TestRegisterHandlers(TestHelpers):
         await self.post_register_start(display_region)
         await self.post_register_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
         await self.post_register_consent_accept(display_region)
         await self.post_register_enter_mobile_valid(display_region)

--- a/tests/unit/test_register_handlers.py
+++ b/tests/unit/test_register_handlers.py
@@ -1,0 +1,28 @@
+from aiohttp.test_utils import unittest_run_loop
+
+from .helpers import TestHelpers
+
+
+# noinspection PyTypeChecker
+class TestWebFormHandlers(TestHelpers):
+    user_journey = 'register'
+    display_region = 'en'
+
+    def check_content_register(self, display_region, contents):
+        self.assertCorrectHeadTitleTag(display_region, 'Take part in a survey', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectPageTitle('Take part in a survey', contents)
+        self.assertIn('How to register a child', contents)
+
+    async def get_register(self, display_region):
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('GET', self.get_register_en)
+            self.assertLogEvent(cm, self.build_url_log_entry('register', display_region, 'GET',
+                                                             include_request_type=False, include_page=False))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register(display_region, str(await get_response.content.read()))
+
+    @unittest_run_loop
+    async def test_register(self):
+        await self.get_register('en')

--- a/tests/unit/test_register_handlers.py
+++ b/tests/unit/test_register_handlers.py
@@ -13,7 +13,22 @@ class TestRegisterHandlers(TestHelpers):
         self.assertSiteLogo(display_region, contents)
         self.assertNotExitButton(display_region, contents)
         self.assertCorrectPageTitle('Take part in a survey', contents)
-        self.assertIn('How to register a child', contents)
+        self.assertIn('COVID-19 Schools Infection Survey (SIS)', contents)
+
+    def check_content_register_sis2(self, display_region, contents):
+        self.assertCorrectHeadTitleTag(display_region, 'COVID-19 Schools Infection Survey (SIS)', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectPageTitle('COVID-19 Schools Infection Survey (SIS)', contents)
+        self.assertIn('How to take part', contents)
+
+    def check_content_register_school_list(self, display_region, contents):
+        self.assertCorrectHeadTitleTag(display_region, 'SIS school list', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectPageTitle('Schools taking part in SIS', contents)
+        self.assertIn("The following schools are taking part in the survey. If your child\\\'s school is not listed, "
+                      "they will not be able to take part.", contents)
 
     def check_content_register_start(self, display_region, contents):
         self.assertCorrectHeadTitleTag(display_region, 'Start registration', contents, error=False)
@@ -187,6 +202,24 @@ class TestRegisterHandlers(TestHelpers):
                                                              include_request_type=False, include_page=False))
             self.assertEqual(200, get_response.status)
             self.check_content_register(display_region, str(await get_response.content.read()))
+
+    async def get_register_sis2(self, display_region):
+        url_get = self.get_url_from_class('RegisterSIS', 'get', display_region=display_region)
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('GET', url_get)
+            self.assertLogEvent(cm, self.build_url_log_entry('sis', display_region, 'GET',
+                                                             include_request_type=False, include_page=True))
+            self.assertEqual(200, get_response.status)
+            self.check_content_register_sis2(display_region, str(await get_response.content.read()))
+
+    async def get_register_school_list(self, display_region):
+        url_get = self.get_url_from_class('RegisterSchoolList', 'get', display_region=display_region)
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('GET', url_get)
+            self.assertLogEvent(cm, self.build_url_log_entry('school-list', display_region, 'GET',
+                                                             include_request_type=False, include_page=True))
+            self.assertEqual(200, get_response.status)
+            self.check_content_register_school_list(display_region, str(await get_response.content.read()))
 
     async def get_register_start(self, display_region):
         url_get = self.get_url_from_class('RegisterStart', 'get', display_region=display_region, request_type='person')
@@ -570,6 +603,8 @@ class TestRegisterHandlers(TestHelpers):
     async def test_register_basic_happy_path_en(self):
         display_region = 'en'
         await self.get_register(display_region)
+        await self.get_register_sis2(display_region)
+        await self.get_register_school_list(display_region)
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
         await self.post_register_parent_enter_name_valid(display_region)

--- a/tests/unit/test_register_handlers.py
+++ b/tests/unit/test_register_handlers.py
@@ -22,15 +22,37 @@ class TestRegisterHandlers(TestHelpers):
         self.assertCorrectPageTitle('Register a child', contents)
         self.assertIn('Start', contents)
 
-    def check_content_register_enter_name(self, display_region, contents, error=None, change=False):
+    def check_content_register_enter_parent_name(self, display_region, contents, error=None):
         title_tag = 'Enter name'
         if error:
             if error == 'first_name':
-                error_text = 'Enter your first name'
+                error_text = "Enter your first name"
                 self.assertErrorMessageDisplayed(display_region, 'answer', error_text, 'error_first_name',
                                                  error_text, contents)
             else:
-                error_text = 'Enter your last name'
+                error_text = "Enter your last name"
+                self.assertErrorMessageDisplayed(display_region, 'answer', error_text, 'error_last_name',
+                                                 error_text, contents)
+            self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=True)
+            self.assertIn(error_text, contents)
+        else:
+            self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectQuestionText("What is the parent/guardian\\\'s name?", contents)
+        self.assertIn('First name', contents)
+        self.assertIn('Middle name(s)', contents)
+        self.assertIn('Last name', contents)
+
+    def check_content_register_enter_child_name(self, display_region, contents, error=None, change=False):
+        title_tag = 'Enter child name'
+        if error:
+            if error == 'first_name':
+                error_text = "Enter your child\\\'s first name"
+                self.assertErrorMessageDisplayed(display_region, 'answer', error_text, 'error_first_name',
+                                                 error_text, contents)
+            else:
+                error_text = "Enter your child\\\'s last name"
                 self.assertErrorMessageDisplayed(display_region, 'answer', error_text, 'error_last_name',
                                                  error_text, contents)
             self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=True)
@@ -80,8 +102,8 @@ class TestRegisterHandlers(TestHelpers):
             self.assertIn('value="2011"', contents)
         self.assertIn('For example, 31 3 1980', contents)
 
-    def check_content_register_person_summary(self, display_region, contents, change=None):
-        self.assertCorrectHeadTitleTag(display_region, 'Person summary', contents, error=False)
+    def check_content_register_child_summary(self, display_region, contents, change=None):
+        self.assertCorrectHeadTitleTag(display_region, 'Child summary', contents, error=False)
         self.assertSiteLogo(display_region, contents)
         self.assertNotExitButton(display_region, contents)
         self.assertCorrectPageTitle('Check answers', contents)
@@ -134,8 +156,8 @@ class TestRegisterHandlers(TestHelpers):
         self.assertIn('UK mobile number', contents)
         self.assertIn('This will be stored and used to send study access codes', contents)
 
-    def check_content_register_confirm_registration(self, display_region, contents, error=None):
-        title_tag = 'Confirm your registration'
+    def check_content_register_confirm_mobile(self, display_region, contents, error=None):
+        title_tag = 'Confirm your mobile'
         if error:
             error_text = 'Select an answer'
             self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=True)
@@ -147,7 +169,7 @@ class TestRegisterHandlers(TestHelpers):
         self.assertSiteLogo(display_region, contents)
         self.assertNotExitButton(display_region, contents)
         self.assertCorrectQuestionText('Is this mobile number correct?', contents)
-        self.assertIn('Yes, process my registration', contents)
+        self.assertIn('Yes, my mobile number is correct', contents)
         self.assertIn('No, I need to change it', contents)
 
     def check_content_register_complete(self, display_region, contents):
@@ -185,26 +207,26 @@ class TestRegisterHandlers(TestHelpers):
             self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_enter_name(display_region, str(await get_response.content.read()))
+            self.check_content_register_enter_parent_name(display_region, str(await get_response.content.read()))
 
-    async def post_register_enter_name_valid(self, display_region):
+    async def post_register_parent_enter_name_valid(self, display_region):
         url_post = self.get_url_from_class('RegisterEnterName', 'post',
                                            display_region=display_region, request_type='person')
-        data = {'name_first_name': 'Belinda', 'name_middle_names': 'Olivia',
+        data = {'name_first_name': 'Robert', 'name_middle_names': 'Kingston',
                 'name_last_name': 'Bobbington', 'action[save_continue]': ''}
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('POST', url_post, data=data)
             self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('select-school', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_select_school(display_region, str(await get_response.content.read()))
+            self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()))
 
-    async def post_register_enter_name_invalid_first(self, display_region):
+    async def post_register_parent_enter_name_invalid_first(self, display_region):
         url_post = self.get_url_from_class('RegisterEnterName', 'post',
                                            display_region=display_region, request_type='person')
-        data = {'name_first_name': '', 'name_middle_names': 'Olivia',
+        data = {'name_first_name': '', 'name_middle_names': 'Kingston',
                 'name_last_name': 'Bobbington', 'action[save_continue]': ''}
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('POST', url_post, data=data)
@@ -213,13 +235,13 @@ class TestRegisterHandlers(TestHelpers):
             self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_enter_name(display_region, str(await get_response.content.read()),
-                                                   error='first_name')
+            self.check_content_register_enter_parent_name(display_region, str(await get_response.content.read()),
+                                                          error='first_name')
 
-    async def post_register_enter_name_invalid_last(self, display_region):
+    async def post_register_parent_enter_name_invalid_last(self, display_region):
         url_post = self.get_url_from_class('RegisterEnterName', 'post',
                                            display_region=display_region, request_type='person')
-        data = {'name_first_name': 'Belinda', 'name_middle_names': 'Olivia',
+        data = {'name_first_name': 'Robert', 'name_middle_names': 'Kingston',
                 'name_last_name': '', 'action[save_continue]': ''}
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('POST', url_post, data=data)
@@ -228,31 +250,75 @@ class TestRegisterHandlers(TestHelpers):
             self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_enter_name(display_region, str(await get_response.content.read()),
-                                                   error='last_name')
+            self.check_content_register_enter_parent_name(display_region, str(await get_response.content.read()),
+                                                          error='last_name')
 
-    async def process_register_name_change(self, display_region):
-        url_get = self.get_url_from_class('RegisterEnterName', 'get',
+    async def post_register_child_enter_name_valid(self, display_region):
+        url_post = self.get_url_from_class('RegisterEnterChildName', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'name_first_name': 'Belinda', 'name_middle_names': 'Olivia',
+                'name_last_name': 'Bobbington', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-child-name', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('select-school', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(200, get_response.status)
+            self.check_content_register_select_school(display_region, str(await get_response.content.read()))
+
+    async def post_register_child_enter_name_invalid_first(self, display_region):
+        url_post = self.get_url_from_class('RegisterEnterChildName', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'name_first_name': '', 'name_middle_names': 'Olivia',
+                'name_last_name': 'Bobbington', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-child-name', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-child-name', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(200, get_response.status)
+            self.check_content_register_enter_child_name(display_region, str(await get_response.content.read()),
+                                                         error='first_name')
+
+    async def post_register_child_enter_name_invalid_last(self, display_region):
+        url_post = self.get_url_from_class('RegisterEnterChildName', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'name_first_name': 'Belinda', 'name_middle_names': 'Olivia',
+                'name_last_name': '', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-child-name', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-child-name', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(200, get_response.status)
+            self.check_content_register_enter_child_name(display_region, str(await get_response.content.read()),
+                                                         error='last_name')
+
+    async def process_register_child_name_change(self, display_region):
+        url_get = self.get_url_from_class('RegisterEnterChildName', 'get',
                                           display_region=display_region, request_type='person')
-        url_post = self.get_url_from_class('RegisterEnterName', 'post',
+        url_post = self.get_url_from_class('RegisterEnterChildName', 'post',
                                            display_region=display_region, request_type='person')
         data = {'name_first_name': 'Beverly', 'name_middle_names': 'Ophelia',
                 'name_last_name': 'Bobbington', 'action[save_continue]': ''}
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('GET', url_get)
-            self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-child-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_enter_name(display_region, str(await get_response.content.read()),
-                                                   change=True)
+            self.check_content_register_enter_child_name(display_region, str(await get_response.content.read()),
+                                                         change=True)
             post_response = await self.client.request('POST', url_post, data=data)
-            self.assertLogEvent(cm, self.build_url_log_entry('enter-name', display_region, 'POST',
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-child-name', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('child-summary', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, post_response.status)
-            self.check_content_register_person_summary(display_region, str(await post_response.content.read()),
-                                                       change='name')
+            self.check_content_register_child_summary(display_region, str(await post_response.content.read()),
+                                                      change='name')
 
     async def post_register_select_school(self, display_region):
         url_post = self.get_url_from_class('RegisterSelectSchool', 'post',
@@ -298,11 +364,11 @@ class TestRegisterHandlers(TestHelpers):
             post_response = await self.client.request('POST', url_post, data=data)
             self.assertLogEvent(cm, self.build_url_log_entry('select-school', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('child-summary', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, post_response.status)
-            self.check_content_register_person_summary(display_region, str(await post_response.content.read()),
-                                                       change='school')
+            self.check_content_register_child_summary(display_region, str(await post_response.content.read()),
+                                                      change='school')
 
     async def post_register_child_dob(self, display_region):
         url_post = self.get_url_from_class('RegisterChildDOB', 'post',
@@ -312,10 +378,10 @@ class TestRegisterHandlers(TestHelpers):
             get_response = await self.client.request('POST', url_post, data=data)
             self.assertLogEvent(cm, self.build_url_log_entry('child-dob', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('child-summary', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_person_summary(display_region, str(await get_response.content.read()))
+            self.check_content_register_child_summary(display_region, str(await get_response.content.read()))
 
     async def post_register_child_dob_empty(self, display_region):
         url_post = self.get_url_from_class('RegisterChildDOB', 'post',
@@ -347,23 +413,23 @@ class TestRegisterHandlers(TestHelpers):
             post_response = await self.client.request('POST', url_post, data=data)
             self.assertLogEvent(cm, self.build_url_log_entry('child-dob', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('child-summary', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, post_response.status)
-            self.check_content_register_person_summary(display_region, str(await post_response.content.read()),
-                                                       change='dob')
+            self.check_content_register_child_summary(display_region, str(await post_response.content.read()),
+                                                      change='dob')
 
     async def post_register_person_summary(self, display_region):
-        url_post = self.get_url_from_class('RegisterPersonSummary', 'post',
+        url_post = self.get_url_from_class('RegisterChildSummary', 'post',
                                            display_region=display_region, request_type='person')
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('POST', url_post)
-            self.assertLogEvent(cm, self.build_url_log_entry('person-summary', display_region, 'POST',
+            self.assertLogEvent(cm, self.build_url_log_entry('child-summary', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('complete', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_consent(display_region, str(await get_response.content.read()))
+            self.check_content_register_complete(display_region, str(await get_response.content.read()))
 
     async def post_register_consent_accept(self, display_region):
         url_post = self.get_url_from_class('RegisterConsent', 'post',
@@ -373,10 +439,10 @@ class TestRegisterHandlers(TestHelpers):
             get_response = await self.client.request('POST', url_post, data=data)
             self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-child-name', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()))
+            self.check_content_register_enter_child_name(display_region, str(await get_response.content.read()))
 
     async def post_register_consent_declined(self, display_region):
         url_post = self.get_url_from_class('RegisterConsent', 'post',
@@ -413,10 +479,10 @@ class TestRegisterHandlers(TestHelpers):
             self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, 'valid mobile number')
-            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()))
+            self.check_content_register_confirm_mobile(display_region, str(await get_response.content.read()))
 
     async def post_register_enter_mobile_empty(self, display_region):
         url_post = self.get_url_from_class('RegisterEnterMobile', 'post',
@@ -446,59 +512,59 @@ class TestRegisterHandlers(TestHelpers):
             self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()),
                                                      error='invalid')
 
-    async def post_register_confirm_registration_yes(self, display_region):
-        url_post = self.get_url_from_class('RegisterConfirmRegistration', 'post',
+    async def post_register_confirm_mobile_yes(self, display_region):
+        url_post = self.get_url_from_class('RegisterConfirmMobile', 'post',
                                            display_region=display_region, request_type='person')
         data = {'request-mobile-confirmation': 'yes', 'action[save_continue]': ''}
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('POST', url_post, data=data)
-            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'POST',
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-mobile', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('complete', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_complete(display_region, str(await get_response.content.read()))
+            self.check_content_register_consent(display_region, str(await get_response.content.read()))
 
-    async def post_register_confirm_registration_no(self, display_region):
-        url_post = self.get_url_from_class('RegisterConfirmRegistration', 'post',
+    async def post_register_confirm_mobile_no(self, display_region):
+        url_post = self.get_url_from_class('RegisterConfirmMobile', 'post',
                                            display_region=display_region, request_type='person')
         data = {'request-mobile-confirmation': 'no', 'action[save_continue]': ''}
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('POST', url_post, data=data)
-            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'POST',
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-mobile', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
             self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
             self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()))
 
-    async def post_register_confirm_registration_missing(self, display_region):
-        url_post = self.get_url_from_class('RegisterConfirmRegistration', 'post',
+    async def post_register_confirm_mobile_missing(self, display_region):
+        url_post = self.get_url_from_class('RegisterConfirmMobile', 'post',
                                            display_region=display_region, request_type='person')
         data = {}
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('POST', url_post, data=data)
-            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'POST',
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-mobile', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()),
-                                                             error='empty')
+            self.check_content_register_confirm_mobile(display_region, str(await get_response.content.read()),
+                                                       error='empty')
 
-    async def post_register_confirm_registration_invalid(self, display_region):
-        url_post = self.get_url_from_class('RegisterConfirmRegistration', 'post',
+    async def post_register_confirm_mobile_invalid(self, display_region):
+        url_post = self.get_url_from_class('RegisterConfirmMobile', 'post',
                                            display_region=display_region, request_type='person')
         data = {'request-mobile-confirmation': 'cheese', 'action[save_continue]': ''}
         with self.assertLogs('respondent-home', 'INFO') as cm:
             get_response = await self.client.request('POST', url_post, data=data)
-            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'POST',
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-mobile', display_region, 'POST',
                                                              include_request_type=True, include_page=True))
-            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-mobile', display_region, 'GET',
                                                              include_request_type=True, include_page=True))
             self.assertEqual(200, get_response.status)
-            self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()),
-                                                             error='invalid')
+            self.check_content_register_confirm_mobile(display_region, str(await get_response.content.read()),
+                                                       error='invalid')
 
     @unittest_run_loop
     async def test_register_basic_happy_path_en(self):
@@ -506,45 +572,75 @@ class TestRegisterHandlers(TestHelpers):
         await self.get_register(display_region)
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
-        await self.post_register_select_school(display_region)
-        await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
-        await self.post_register_consent_accept(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
         await self.post_register_enter_mobile_valid(display_region)
-        await self.post_register_confirm_registration_yes(display_region)
-
-    @unittest_run_loop
-    async def test_register_name_change_en(self):
-        display_region = 'en'
-        await self.get_register_start(display_region)
-        await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_child_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
         await self.post_register_child_dob(display_region)
         await self.post_register_person_summary(display_region)
-        await self.process_register_name_change(display_region)
 
     @unittest_run_loop
-    async def test_register_enter_name_invalid_first_name_en(self):
+    async def test_register_parent_enter_name_invalid_first_name_en(self):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_invalid_first(display_region)
+        await self.post_register_parent_enter_name_invalid_first(display_region)
 
     @unittest_run_loop
-    async def test_register_enter_name_invalid_last_name_en(self):
+    async def test_register_parent_enter_name_invalid_last_name_en(self):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_invalid_last(display_region)
+        await self.post_register_parent_enter_name_invalid_last(display_region)
+
+    @unittest_run_loop
+    async def test_register_child_name_change_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_child_enter_name_valid(display_region)
+        await self.post_register_select_school(display_region)
+        await self.post_register_child_dob(display_region)
+        await self.process_register_child_name_change(display_region)
+
+    @unittest_run_loop
+    async def test_register_child_enter_name_invalid_first_name_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_child_enter_name_invalid_first(display_region)
+
+    @unittest_run_loop
+    async def test_register_child_enter_name_invalid_last_name_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_child_enter_name_invalid_last(display_region)
 
     @unittest_run_loop
     async def test_register_school_empty_en(self):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_child_enter_name_valid(display_region)
         await self.post_register_select_school_empty(display_region)
 
     @unittest_run_loop
@@ -552,10 +648,13 @@ class TestRegisterHandlers(TestHelpers):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_child_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
         await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
         await self.process_register_school_change(display_region)
 
     @unittest_run_loop
@@ -563,7 +662,11 @@ class TestRegisterHandlers(TestHelpers):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_child_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
         await self.post_register_child_dob_empty(display_region)
 
@@ -572,10 +675,13 @@ class TestRegisterHandlers(TestHelpers):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_child_enter_name_valid(display_region)
         await self.post_register_select_school(display_region)
         await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
         await self.process_register_child_dob_change(display_region)
 
     @unittest_run_loop
@@ -583,10 +689,9 @@ class TestRegisterHandlers(TestHelpers):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
-        await self.post_register_select_school(display_region)
-        await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
         await self.post_register_consent_declined(display_region)
 
     @unittest_run_loop
@@ -594,10 +699,9 @@ class TestRegisterHandlers(TestHelpers):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
-        await self.post_register_select_school(display_region)
-        await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_mobile_yes(display_region)
         await self.post_register_consent_invalid(display_region)
 
     @unittest_run_loop
@@ -605,11 +709,7 @@ class TestRegisterHandlers(TestHelpers):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
-        await self.post_register_select_school(display_region)
-        await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
-        await self.post_register_consent_accept(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
         await self.post_register_enter_mobile_empty(display_region)
 
     @unittest_run_loop
@@ -617,48 +717,32 @@ class TestRegisterHandlers(TestHelpers):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
-        await self.post_register_select_school(display_region)
-        await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
-        await self.post_register_consent_accept(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
         await self.post_register_enter_mobile_invalid(display_region)
 
     @unittest_run_loop
-    async def test_register_confirm_registration_no_en(self):
+    async def test_register_confirm_mobile_no_en(self):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
-        await self.post_register_select_school(display_region)
-        await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
-        await self.post_register_consent_accept(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
         await self.post_register_enter_mobile_valid(display_region)
-        await self.post_register_confirm_registration_no(display_region)
+        await self.post_register_confirm_mobile_no(display_region)
 
     @unittest_run_loop
-    async def test_register_confirm_registration_empty_en(self):
+    async def test_register_confirm_mobile_empty_en(self):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
-        await self.post_register_select_school(display_region)
-        await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
-        await self.post_register_consent_accept(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
         await self.post_register_enter_mobile_valid(display_region)
-        await self.post_register_confirm_registration_missing(display_region)
+        await self.post_register_confirm_mobile_missing(display_region)
 
     @unittest_run_loop
-    async def test_register_confirm_registration_invalid_en(self):
+    async def test_register_confirm_mobile_invalid_en(self):
         display_region = 'en'
         await self.get_register_start(display_region)
         await self.post_register_start(display_region)
-        await self.post_register_enter_name_valid(display_region)
-        await self.post_register_select_school(display_region)
-        await self.post_register_child_dob(display_region)
-        await self.post_register_person_summary(display_region)
-        await self.post_register_consent_accept(display_region)
+        await self.post_register_parent_enter_name_valid(display_region)
         await self.post_register_enter_mobile_valid(display_region)
-        await self.post_register_confirm_registration_invalid(display_region)
+        await self.post_register_confirm_mobile_invalid(display_region)

--- a/tests/unit/test_register_handlers.py
+++ b/tests/unit/test_register_handlers.py
@@ -6,7 +6,7 @@ from .helpers import TestHelpers
 # noinspection PyTypeChecker
 class TestWebFormHandlers(TestHelpers):
     user_journey = 'register'
-    display_region = 'en'
+    request_type = 'person'
 
     def check_content_register(self, display_region, contents):
         self.assertCorrectHeadTitleTag(display_region, 'Take part in a survey', contents, error=False)
@@ -15,14 +15,299 @@ class TestWebFormHandlers(TestHelpers):
         self.assertCorrectPageTitle('Take part in a survey', contents)
         self.assertIn('How to register a child', contents)
 
+    def check_content_register_start(self, display_region, contents):
+        self.assertCorrectHeadTitleTag(display_region, 'Start registration', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectPageTitle('Register a child', contents)
+        self.assertIn('Start', contents)
+
+    def check_content_register_consent(self, display_region, contents):
+        self.assertCorrectHeadTitleTag(display_region, 'Confirm consent', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectPageTitle('Confirm consent', contents)
+        self.assertIn('I accept', contents)
+        self.assertIn('I decline', contents)
+
+    def check_content_register_consent_declined(self, display_region, contents):
+        self.assertCorrectHeadTitleTag(display_region, 'You have been removed from this study', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectPageTitle('You have been removed from this study', contents)
+
+    def check_content_register_enter_mobile(self, display_region, contents, error=None):
+        title_tag = 'Enter mobile number'
+        if error:
+            if error == 'empty':
+                error_text = 'Enter your mobile number'
+                self.assertErrorMessageDisplayed(display_region, 'answer', error_text, 'mobile_empty',
+                                                 error_text, contents)
+            else:
+                error_text = 'Enter a UK mobile number in a valid format, for example, 07700 900345 or +44 7700 900345'
+                self.assertErrorMessageDisplayed(display_region, 'answer', error_text, 'mobile_invalid',
+                                                 error_text, contents)
+            self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=True)
+            self.assertIn(error_text, contents)
+        else:
+            self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectQuestionText('What is your mobile number?', contents)
+        self.assertIn('UK mobile number', contents)
+        self.assertIn('This will be stored and used to send study access codes', contents)
+
+    def check_content_register_confirm_registration(self, display_region, contents, error=None):
+        title_tag = 'Confirm your registration'
+        if error:
+            error_text = 'Select an answer'
+            self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=True)
+            self.assertErrorMessageDisplayed(display_region, 'answer', error_text, 'no-selection',
+                                             error_text, contents)
+            self.assertIn(error_text, contents)
+        else:
+            self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectQuestionText('Is this mobile number correct?', contents)
+        self.assertIn('Yes, process my registration', contents)
+        self.assertIn('No, I need to change it', contents)
+
+    def check_content_register_complete(self, display_region, contents):
+        self.assertCorrectHeadTitleTag(display_region, 'Registration complete', contents, error=False)
+        self.assertSiteLogo(display_region, contents)
+        self.assertNotExitButton(display_region, contents)
+        self.assertCorrectPageTitle('Your children have been registered for the survey', contents)
+        self.assertIn('A text message confirming your registration should arrive soon', contents)
+
     async def get_register(self, display_region):
+        url_get = self.get_url_from_class('Register', 'get', display_region=display_region)
         with self.assertLogs('respondent-home', 'INFO') as cm:
-            get_response = await self.client.request('GET', self.get_register_en)
-            self.assertLogEvent(cm, self.build_url_log_entry('register', display_region, 'GET',
+            get_response = await self.client.request('GET', url_get)
+            self.assertLogEvent(cm, self.build_url_log_entry('', display_region, 'GET',
                                                              include_request_type=False, include_page=False))
             self.assertEqual(get_response.status, 200)
             self.check_content_register(display_region, str(await get_response.content.read()))
 
+    async def get_register_start(self, display_region):
+        url_get = self.get_url_from_class('RegisterStart', 'get', display_region=display_region, request_type='person')
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('GET', url_get)
+            self.assertLogEvent(cm, self.build_url_log_entry('start', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_start(display_region, str(await get_response.content.read()))
+
+    async def post_register_start(self, display_region):
+        url_post = self.get_url_from_class('RegisterStart', 'post',
+                                           display_region=display_region, request_type='person')
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post)
+            self.assertLogEvent(cm, self.build_url_log_entry('start', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_consent(display_region, str(await get_response.content.read()))
+
+    async def post_register_consent_accept(self, display_region):
+        url_post = self.get_url_from_class('RegisterConsent', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'button-accept': 'accept'}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()))
+
+    async def post_register_consent_declined(self, display_region):
+        url_post = self.get_url_from_class('RegisterConsent', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'button-decline': 'decline'}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('consent-declined', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_consent_declined(display_region, str(await get_response.content.read()))
+
+    async def post_register_consent_invalid(self, display_region):
+        url_post = self.get_url_from_class('RegisterConsent', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('consent', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_consent(display_region, str(await get_response.content.read()))
+
+    async def post_register_enter_mobile_valid(self, display_region):
+        url_post = self.get_url_from_class('RegisterEnterMobile', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'request-mobile-number': self.mobile_valid, 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, 'valid mobile number')
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()))
+
+    async def post_register_enter_mobile_empty(self, display_region):
+        url_post = self.get_url_from_class('RegisterEnterMobile', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'request-mobile-number': '', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()),
+                                                     error='empty')
+
+    async def post_register_enter_mobile_invalid(self, display_region):
+        url_post = self.get_url_from_class('RegisterEnterMobile', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'request-mobile-number': 'xxxxxx', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()),
+                                                     error='invalid')
+
+    async def post_register_confirm_registration_yes(self, display_region):
+        url_post = self.get_url_from_class('RegisterConfirmRegistration', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'request-mobile-confirmation': 'yes', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('complete', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_complete(display_region, str(await get_response.content.read()))
+
+    async def post_register_confirm_registration_no(self, display_region):
+        url_post = self.get_url_from_class('RegisterConfirmRegistration', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'request-mobile-confirmation': 'no', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('enter-mobile', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_enter_mobile(display_region, str(await get_response.content.read()))
+
+    async def post_register_confirm_registration_missing(self, display_region):
+        url_post = self.get_url_from_class('RegisterConfirmRegistration', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()),
+                                                             error='empty')
+
+    async def post_register_confirm_registration_invalid(self, display_region):
+        url_post = self.get_url_from_class('RegisterConfirmRegistration', 'post',
+                                           display_region=display_region, request_type='person')
+        data = {'request-mobile-confirmation': 'cheese', 'action[save_continue]': ''}
+        with self.assertLogs('respondent-home', 'INFO') as cm:
+            get_response = await self.client.request('POST', url_post, data=data)
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'POST',
+                                                             include_request_type=True, include_page=True))
+            self.assertLogEvent(cm, self.build_url_log_entry('confirm-registration', display_region, 'GET',
+                                                             include_request_type=True, include_page=True))
+            self.assertEqual(get_response.status, 200)
+            self.check_content_register_confirm_registration(display_region, str(await get_response.content.read()),
+                                                             error='invalid')
+
     @unittest_run_loop
-    async def test_register(self):
-        await self.get_register('en')
+    async def test_register_basic_happy_path_en(self):
+        display_region = 'en'
+        await self.get_register(display_region)
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_registration_yes(display_region)
+
+    @unittest_run_loop
+    async def test_register_consent_declined_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_consent_declined(display_region)
+
+    @unittest_run_loop
+    async def test_register_consent_invalid_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_consent_invalid(display_region)
+
+    @unittest_run_loop
+    async def test_register_mobile_empty_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_enter_mobile_empty(display_region)
+
+    @unittest_run_loop
+    async def test_register_mobile_invalid_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_enter_mobile_invalid(display_region)
+
+    @unittest_run_loop
+    async def test_register_confirm_registration_no_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_registration_no(display_region)
+
+    @unittest_run_loop
+    async def test_register_confirm_registration_empty_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_registration_missing(display_region)
+
+    @unittest_run_loop
+    async def test_register_confirm_registration_invalid_en(self):
+        display_region = 'en'
+        await self.get_register_start(display_region)
+        await self.post_register_start(display_region)
+        await self.post_register_consent_accept(display_region)
+        await self.post_register_enter_mobile_valid(display_region)
+        await self.post_register_confirm_registration_invalid(display_region)


### PR DESCRIPTION
# Motivation and Context
Implements the RHUI part of the registration journey

# What has changed
Implements a range of tickets (see below) to add a register function, in english only, to RHUI, currently build around SIS2
Includes full unit tests
Includes update to version 40.0.1 of the Design System
Notes

- This does not include the call to send the registration to RM via RHSvc, as the new endpoint was not yet available
- The flows are based on the V2 figma diagram supplied by Design - https://www.figma.com/file/TEHetED9GJ1TILPqRXNMLQ/ONS-INT-register-for-a-survey--user-flow?node-id=0%3A1
- The code currently only copes with the registration of a single child - looping for additional children it yet to be decided
- Requires RHCuc update to match because of DS update


# How to test?
New code has full unit test coverage
Journey can be started in RHUI via /en/register/
A school can be found in the autosuggest with the text 'ham'. The implementation currently only includes test data
Completing registration will result in a 'complete' screen, but does not currently trigger the endpoint

# Links
Jira tickets included:

- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-156
- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-157
- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-158
- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-159
- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-160
- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-161
- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-163
- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-164
- https://collaborate2.ons.gov.uk/jira/browse/SOCINT-165

Required RHCuc change
https://github.com/ONSdigital/sdc-int-rh-cucumber/pull/8

# Screenshots (if appropriate):