### PR TITLE
Socint 290 collection instrument url

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -13,7 +13,7 @@ Request = namedtuple('Request', ['method', 'path', 'auth', 'func'])
 
 
 class EqPayloadConstructor(object):
-    def __init__(self, uac_claim_ctx: dict, attributes: dict, app: Application):
+    def __init__(self, uac_context: dict, attributes: dict, app: Application):
         """
         Creates the payload needed to communicate with EQ, built from the RH service
         """
@@ -42,31 +42,31 @@ class EqPayloadConstructor(object):
         self._channel = 'rh'
 
         try:
-            self._case_id = uac_claim_ctx['collectionCase']['caseId']
+            self._case_id = uac_context['collectionCase']['caseId']
         except KeyError:
-            raise InvalidEqPayLoad('No case id in supplied case JSON')
+            raise InvalidEqPayLoad('No case id in supplied UAC context JSON')
 
         try:
-            self._collex_id = uac_claim_ctx['collectionExercise']['collectionExerciseId']
+            self._collex_id = uac_context['collectionExercise']['collectionExerciseId']
         except KeyError:
-            raise InvalidEqPayLoad('No collection id in supplied case JSON')
+            raise InvalidEqPayLoad('No collection id in supplied UAC context JSON')
 
         try:
-            self._questionnaire_id = uac_claim_ctx['qid']
+            self._questionnaire_id = uac_context['qid']
         except KeyError:
-            raise InvalidEqPayLoad('No questionnaireId in supplied case JSON')
+            raise InvalidEqPayLoad('No questionnaireId in supplied UAC context JSON')
 
         self._response_id = self.hash_qid(self._questionnaire_id, salt)
 
         try:
-            self._uprn = uac_claim_ctx['collectionCase']['address']['uprn']
+            self._uprn = uac_context['collectionCase']['address']['uprn']
         except KeyError:
-            raise InvalidEqPayLoad('Could not retrieve address uprn from case JSON')
+            raise InvalidEqPayLoad('Could not retrieve address uprn from UAC context JSON')
 
         try:
-            self._region = uac_claim_ctx['collectionCase']['address']['region'][0]
+            self._region = uac_context['collectionCase']['address']['region'][0]
         except KeyError:
-            raise InvalidEqPayLoad('Could not retrieve region from case JSON')
+            raise InvalidEqPayLoad('Could not retrieve region from UAC context JSON')
 
         if self._region == 'E':
             self._language_code = 'en'
@@ -75,19 +75,19 @@ class EqPayloadConstructor(object):
 
         #   The following are put in as part of SOCINT-258 - temporary for use with POC
         try:
-            self._collex_name = uac_claim_ctx['collectionExercise']['name']
+            self._collex_name = uac_context['collectionExercise']['name']
         except KeyError:
-            raise InvalidEqPayLoad('No collection name supplied in case JSON')
+            raise InvalidEqPayLoad('No collection name supplied in UAC context JSON')
 
         try:
-            self._case_ref = uac_claim_ctx['collectionCase']['caseRef']
+            self._case_ref = uac_context['collectionCase']['caseRef']
         except KeyError:
-            raise InvalidEqPayLoad('No caseRef supplied in case JSON')
+            raise InvalidEqPayLoad('No caseRef supplied in UAC context JSON')
 
         try:
-            self._survey_url = uac_claim_ctx['collectionInstrumentUrl']
+            self._survey_url = uac_context['collectionInstrumentUrl']
         except KeyError:
-            raise InvalidEqPayLoad('No collectionInstrumentUrl in case JSON')
+            raise InvalidEqPayLoad('No collectionInstrumentUrl in UAC context JSON')
 
     async def build(self):
         """__init__ is not a coroutine function, so I/O needs to go here"""

--- a/app/eq.py
+++ b/app/eq.py
@@ -79,6 +79,11 @@ class EqPayloadConstructor(object):
         except KeyError:
             raise InvalidEqPayLoad('No caseRef supplied in case JSON')
 
+        try:
+            self._survey_url = case['collectionInstrumentUrl']
+        except KeyError:
+            raise InvalidEqPayLoad('No collectionInstrumentUrl in case JSON')
+
     async def build(self):
         """__init__ is not a coroutine function, so I/O needs to go here"""
 
@@ -115,8 +120,7 @@ class EqPayloadConstructor(object):
             # The following are put in as part of SOCINT-258 - temporary for use with POC
             'schema_name': 'zzz_9999',
             'period_str': self._collex_name,
-            'survey_url': 'https://raw.githubusercontent.com/ONSdigital/eq-questionnaire-runner/social-demo'
-                          '/test_schemas/en/zzz_9999.json',
+            'survey_url': self._survey_url,
             'case_ref': self._case_ref
         }
         return self._payload

--- a/tests/test_data/rhsvc/uac-w.json
+++ b/tests/test_data/rhsvc/uac-w.json
@@ -5,6 +5,7 @@
    "receiptReceived":false,
    "eqLaunched":false,
    "wave":0,
+   "collectionInstrumentUrl":"https://raw.githubusercontent.com/ONSdigital/eq-questionnaire-runner/social-demo/test_schemas/en/zzz_9999.json",
    "survey":{
       "surveyId":"3883af91-0052-4497-9805-3238544fcf8a",
       "name":"LMS"

--- a/tests/test_data/rhsvc/uac_e.json
+++ b/tests/test_data/rhsvc/uac_e.json
@@ -5,6 +5,7 @@
    "receiptReceived":false,
    "eqLaunched":false,
    "wave":0,
+   "collectionInstrumentUrl":"https://raw.githubusercontent.com/ONSdigital/eq-questionnaire-runner/social-demo/test_schemas/en/zzz_9999.json",
    "surveyLiteDTO":{
       "surveyId":"3883af91-0052-4497-9805-3238544fcf8a",
       "name":"LMS"

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -11,40 +11,50 @@ class TestEq(RHTestCase):
         self.assertIsInstance(
             EqPayloadConstructor(self.uac_json_e, self.attributes_en, self.app), EqPayloadConstructor)
 
+    def verify_missing(self, uac_json, expected_msg):
+        with self.assertRaises(InvalidEqPayLoad) as ex:
+            EqPayloadConstructor(uac_json, self.attributes_en, self.app)
+        self.assertIn(expected_msg, ex.exception.message)
+
     def test_create_eq_constructor_missing_case_id(self):
         uac_json = self.uac_json_e.copy()
         del uac_json['collectionCase']['caseId']
-
-        with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.attributes_en, self.app)
-        self.assertIn('No case id in supplied case JSON', ex.exception.message)
+        self.verify_missing(uac_json, 'No case id in supplied UAC context JSON')
 
     def test_create_eq_constructor_missing_ce_id(self):
         uac_json = self.uac_json_e.copy()
         del uac_json['collectionExercise']['collectionExerciseId']
-
-        with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.attributes_en, self.app)
-        self.assertIn(f'No collection id in supplied case JSON',
-                      ex.exception.message)
+        self.verify_missing(uac_json, 'No collection id in supplied UAC context JSON')
 
     def test_create_eq_constructor_missing_questionnaire_id(self):
         uac_json = self.uac_json_e.copy()
         del uac_json['qid']
-
-        with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.attributes_en, self.app)
-            self.assertIn(f'No qid in supplied case JSON',
-                          ex.exception.message)
+        self.verify_missing(uac_json, 'No questionnaireId in supplied UAC context JSON')
 
     def test_create_eq_constructor_missing_uprn(self):
         uac_json = self.uac_json_e.copy()
         del uac_json['collectionCase']['address']['uprn']
+        self.verify_missing(uac_json, 'Could not retrieve address uprn from UAC context JSON')
 
-        with self.assertRaises(InvalidEqPayLoad) as ex:
-            EqPayloadConstructor(uac_json, self.attributes_en, self.app)
-            self.assertIn(f'Could not retrieve address uprn from case JSON',
-                          ex.exception.message)
+    def test_create_eq_constructor_missing_region(self):
+        uac_json = self.uac_json_e.copy()
+        del uac_json['collectionCase']['address']['region']
+        self.verify_missing(uac_json, 'Could not retrieve region from UAC context JSON')
+
+    def test_create_eq_constructor_missing_collection_name(self):
+        uac_json = self.uac_json_e.copy()
+        del uac_json['collectionExercise']['name']
+        self.verify_missing(uac_json, 'No collection name supplied in UAC context JSON')
+
+    def test_create_eq_constructor_missing_collection_case_ref(self):
+        uac_json = self.uac_json_e.copy()
+        del uac_json['collectionCase']['caseRef']
+        self.verify_missing(uac_json, 'No caseRef supplied in UAC context JSON')
+
+    def test_create_eq_constructor_missing_survey_url(self):
+        uac_json = self.uac_json_e.copy()
+        del uac_json['collectionInstrumentUrl']
+        self.verify_missing(uac_json, 'No collectionInstrumentUrl in UAC context JSON')
 
     @unittest_run_loop
     async def test_build_en(self):


### PR DESCRIPTION
# Motivation and Context
Add `collectionInstrumentUrl` to the GET /uacs response and use it as part of EQ token construction.

**NOTE: this has to be merged with the RHSvc SOCINT-257 PR, and t RH-cucumber SOCINT-257 PR.**

# What has changed
EQ token construction and some test data

# How to test?
manually, and with RH cucumber.

# Links
JIRA LINK: https://collaborate2.ons.gov.uk/jira/browse/SOCINT-290
