### PR TITLE
Remove link and paragraph to request new UAC

### DIFF
--- a/app/templates/start.html
+++ b/app/templates/start.html
@@ -85,9 +85,4 @@
         'submitType': 'loader'
     }) }}
 
-    <h2>{{_("If you don’t have an access code")}}</h2>
-    {% autoescape false %}
-        <p>{{ _('You can %(open)srequest a new access code%(close)s to start a new study if you have lost or not received an access code. This can be sent to you by text, post or email.', open='<a href="%s">' % request_access_code_link, close='</a>')|safe }}</p>
-    {% endautoescape %}
-
 {% endblock %}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to remove the link to request a new UAC from the start page
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Paragraph and link removed
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run this branch or build the docker image and make up. Navigate to `localhost:9092/en/start` and check the paragraph and link to request a new UAC is no longer there (the `Access survey` button should be the last thing on the page before the footer).
Run [cucumber tests on the same branch name](https://github.com/ONSdigital/sdc-int-rh-cucumber/pull/29) and check they pass.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/CpvWn2jw/13-rhui-remove-request-uac-link-5

# Screenshots (if appropriate):