### PR TITLE
Changed contact us link to standard ONS one

### DIFF
--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -28,7 +28,7 @@
                     },
                     {
                         'text': 'Cysylltu â ni',
-                        'url': domain_url_cy + '/cysylltu-a-ni/'
+                        'url': 'https://cy.ons.gov.uk/aboutus/contactus/surveyenquiries'
                     }
                 ]
             }

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -27,7 +27,7 @@
                     },
                     {
                         'text': 'Contact us',
-                        'url': domain_url_en + '/contact-us/'
+                        'url': 'https://www.ons.gov.uk/aboutus/contactus/surveyenquiries'
                     }
                 ]
             }

--- a/app/templates/start-uac-inactive.html
+++ b/app/templates/start-uac-inactive.html
@@ -7,6 +7,4 @@
     </h1>
 {#TODO: Needs content design say your UAC is inactive, and support line number/page#}
 
-    <p>{{ _('Thank you for your help.') }}</p>
-
 {%- endblock main -%}

--- a/app/utils.py
+++ b/app/utils.py
@@ -55,9 +55,9 @@ class View:
                 link = base_en
         elif requested_link == 'contact-us':
             if display_region == 'cy':
-                link = base_cy + '/cysylltu-a-ni/'
+                link = 'https://cy.ons.gov.uk/aboutus/contactus/surveyenquiries'
             else:
-                link = base_en + '/contact-us/'
+                link = 'https://www.ons.gov.uk/aboutus/contactus/surveyenquiries'
         elif requested_link == 'privacy':
             if display_region == 'cy':
                 link = base_cy + '/preifatrwydd-a-diogelu-data/'


### PR DESCRIPTION
# Motivation and Context
The 'Contact Us' link on each page didn't lead anywhere anymore and needed updating

# What has changed
Switched to the generic ONS Contact Us page and removed unneeded text