### PR TITLE
Fix to displaying the chosen cookie choices

### DIFF
--- a/app/templates/cookies.html
+++ b/app/templates/cookies.html
@@ -6,6 +6,8 @@
 {% from "components/table/_macro.njk" import onsTable %}
 {% from "components/lists/_macro.njk" import onsList %}
 
+{% set page_title = "Cookies on start.surveys.ons.gov.uk" %}
+
 {%- block main -%}
 
     {% call onsPanel({
@@ -15,6 +17,7 @@
         <h2>Your cookie settings have been saved</h2>
         <p>Some parts of start.surveys.ons.gov.uk may use additional cookies and will have their own cookie policy and
             banner.</p>
+        <a class="ons-js-return-link ons-u-mt-s ons-u-dib" href="#0">Return to previous page</a>
     {% endcall %}
     <h1 class="ons-u-fs-xxl">Cookies on start.surveys.ons.gov.uk</h1>
     <p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>

--- a/app/templates/start.html
+++ b/app/templates/start.html
@@ -21,6 +21,8 @@
     {%- set error_uac = {'id': 'uac_empty', 'text': _('Enter an access code')} -%}
 {%- elif 'uac_invalid' in field_messages_dict -%}
     {%- set error_uac = {'id': 'uac_invalid', 'text': _('Enter a valid access code')} -%}
+{%- else -%}
+    {%- set error_uac = None -%}
 {%- endif -%}
 
 {% block main %}

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="55.2.0"
+DESIGN_SYSTEM_VERSION="55.1.0"
 
 TEMP_DIR=$(mktemp -d)
 

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="44.0.2"
+DESIGN_SYSTEM_VERSION="55.2.0"
 
 TEMP_DIR=$(mktemp -d)
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -269,9 +269,9 @@ class RHTestCase(AioHTTPTestCase):
             else:
                 panel_label_text = 'There is a problem with this page'
 
-        self.assertIn('<h2 id="error-summary-title" data-qa="error-header" class="ons-panel__title ons-u-fs-r--b">'
+        self.assertIn('<h2 id="alert" data-qa="error-header" class="ons-panel__title ons-u-fs-r--b">'
                       + panel_label_text + '</h2>', content)
-        self.assertIn('<a href="#' + field_name + '" class="ons-list__link  js-inpagelink">' + list_error + '</a>',
+        self.assertIn('<a href="#' + field_name + '" class="ons-list__link js-inpagelink">' + list_error + '</a>',
                       content)
         self.assertIn('<strong>' + field_error + '</strong>', content)
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The cookie choice radio buttons were not showing the saved cookie choice when returning to the cookie page
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The load templates script now pulls the previous to latest version of the design system as there is an issue with the latest where the if statement in macro code for the uacInputBox has no default and therefore fails with an error.
The hack to get around this is by setting error to None in start.html.

Return link added when cookies are saved (this is required for this to work)
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
make test
Run ATs on branch of the same name
Go to the cookies page, make your choices and click save. Navigate away to a different page. Navigate back to the cookie page, are your choices still displayed?
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/FBJZ4TIC/305-rh-ui-session-not-saving-the-cookie-choices-made-by-the-respondent-1-day
# Screenshots (if appropriate):