### PR TITLE
minimal required to remove welsh routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ First, run scripts/load_templates.sh to pull the current/correct version of the 
 
 Then to run this application in development use, run 'run.py'
 
-and access using [http://localhost:9092/en/start/](http://localhost:9092/en/start/) or [http://localhost:9092/cy/start/](http://localhost:9092/cy/start/).
+and access using [http://localhost:9092/en/start/](http://localhost:9092/en/start/)
 
 You can also run RH UI and its dependencies in Docker.
 See the [Readme](docker/README.md) in the docker directory for details.

--- a/app/config.py
+++ b/app/config.py
@@ -44,7 +44,7 @@ class BaseConfig:
 
     DOMAIN_URL_PROTOCOL = env('DOMAIN_URL_PROTOCOL', default='https://')
     DOMAIN_URL_EN = env('DOMAIN_URL_EN')
-    DOMAIN_URL_CY = env('DOMAIN_URL_CY')
+    DOMAIN_URL_CY = ''
 
     ACCOUNT_SERVICE_URL = env('ACCOUNT_SERVICE_URL')
     EQ_URL = env('EQ_URL')
@@ -88,7 +88,7 @@ class DevelopmentConfig:
 
     DOMAIN_URL_PROTOCOL = 'http://'
     DOMAIN_URL_EN = env.str('DOMAIN_URL_EN', default='localhost:9092')
-    DOMAIN_URL_CY = env.str('DOMAIN_URL_CY', default='localhost:9092')
+    DOMAIN_URL_CY = ''
 
     ACCOUNT_SERVICE_URL = env.str('ACCOUNT_SERVICE_URL',
                                   default='http://localhost:9092')
@@ -130,7 +130,7 @@ class TestingConfig:
 
     DOMAIN_URL_PROTOCOL = 'http://'
     DOMAIN_URL_EN = 'localhost:9092'
-    DOMAIN_URL_CY = 'localhost:9092'
+    DOMAIN_URL_CY = ''
 
     ACCOUNT_SERVICE_URL = 'http://localhost:9092'
     EQ_URL = 'http://localhost:5000'

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -27,17 +27,9 @@ def create_error_middleware(overrides):
             override = overrides.get(resp.status)
             return await override(request) if override else resp
         except web.HTTPNotFound:
-            path_prefix = request.app['URL_PATH_PREFIX']
-
-            def path_starts_with(suffix):
-                return request.path.startswith(path_prefix + suffix)
-
             index_resource = request.app.router['Start:get']
 
-            if path_starts_with('/cy'):
-                display_region = 'cy'
-            else:
-                display_region = 'en'
+            display_region = 'en'
 
             if request.path + '/' == index_resource.canonical.replace('{display_region}', display_region):
                 logger.debug('redirecting to index',
@@ -231,10 +223,6 @@ def setup(app):
 
 
 def check_display_region(request):
-    path_prefix = request.app['URL_PATH_PREFIX']
-
-    def path_starts_with(suffix):
-        return request.path.startswith(path_prefix + suffix)
 
     domain_url_en = request.app['DOMAIN_URL_PROTOCOL'] + request.app[
         'DOMAIN_URL_EN']
@@ -247,18 +235,9 @@ def check_display_region(request):
         'page_url': View.gen_page_url(request)
     }
 
-    if path_starts_with('/cy'):
-        return {
-            **base_attributes,
-            'display_region': 'cy',
-            'locale': 'cy',
-            'page_title': 'Gwall',
-            'contact_us_link': View.get_campaign_site_link(request, 'cy', 'contact-us')
-        }
-    else:
-        return {
-            **base_attributes,
-            'display_region': 'en',
-            'page_title': 'Error',
-            'contact_us_link': View.get_campaign_site_link(request, 'en', 'contact-us')
-        }
+    return {
+        **base_attributes,
+        'display_region': 'en',
+        'page_title': 'Error',
+        'contact_us_link': View.get_campaign_site_link(request, 'en', 'contact-us')
+    }

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -12,8 +12,7 @@
             'iconType': 'exit',
             'iconPosition': 'after',
             'url': url('StartExit:get', display_region='en')
-        }
-    -%}
+        }-%}
 {%- endif -%}
 
 {%- set footer_content = {
@@ -53,8 +52,7 @@
         'copyrightDeclaration': {
             'copyright': 'Crown copyright and database rights 2020 OS 100019153.'
         }
-    }
--%}
+    }-%}
 
 {%- if page_url -%}
     {%- set language = { 'languages':
@@ -69,17 +67,10 @@
                 'current': true
             },
             {
-                'url': '/cy' + page_url,
-                'ISOCode': 'cy',
-                'text': 'Cymraeg',
-                'buttonAriaLabel': 'Dewisydd iaith. Iaith gyfredol: Cymraeg',
-                'chooseLanguage': 'Dewiswch iaith',
-                'allLanguages': 'Pob iaith',
                 'current': false
             }
         ]
-}
-    -%}
+}-%}
 {%- endif -%}
 
 {%- set pageConfig = {
@@ -97,12 +88,10 @@
 {%- block preHeader -%}
 
     {%- from 'components/cookies-banner/_macro.njk' import onsCookiesBanner -%}
-    {{
-        onsCookiesBanner({
+    {{ onsCookiesBanner({
             "statementTitle": 'Tell us whether you accept cookies',
             "statementText": 'We use <a href="' + domain_url_en + '/cookies/' + '">cookies to collect information</a> about how you use start.surveys.ons.gov.uk. We use this information to make the website work as well as possible and improve our services.',
             "confirmationText": 'You’ve accepted all cookies. You can <a href="' + domain_url_en + '/cookies/' + '">change your cookie preferences</a> at any time.',
             "secondaryButtonUrl": domain_url_en + '/cookies/'
-        })
-    }}
+        }) }}
 {%- endblock -%}

--- a/app/utils.py
+++ b/app/utils.py
@@ -8,7 +8,7 @@ uk_zone = timezone('Europe/London')
 
 
 class View:
-    valid_display_regions = r'{display_region:\ben|cy\b}'
+    valid_display_regions = r'{display_region:\ben\b}'
     valid_display_regions_en_only = r'{display_region:\ben\b}'
     valid_user_journeys = r'{user_journey:\bstart|request\b}'
     page_title_error_prefix_en = 'Error: '
@@ -27,7 +27,7 @@ class View:
     @staticmethod
     def gen_page_url(request):
         full_url = str(request.rel_url)
-        if full_url[:3] == '/en' or full_url[:3] == '/cy':
+        if full_url[:3] == '/en':
             generic_url = full_url[3:]
         else:
             generic_url = full_url

--- a/kubernetes/dev.yml
+++ b/kubernetes/dev.yml
@@ -49,11 +49,6 @@ spec:
             configMapKeyRef:
               name: domains
               key: en-host
-        - name: DOMAIN_URL_CY
-          valueFrom:
-            configMapKeyRef:
-              name: domains
-              key: cy-host
         - name: ADDRESS_INDEX_SVC_URL
           valueFrom:
             configMapKeyRef:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -275,33 +275,6 @@ class RHTestCase(AioHTTPTestCase):
                       content)
         self.assertIn('<strong>' + field_error + '</strong>', content)
 
-    def assertCorrectTranslationLink(self, content, display_region, user_journey, request_type=None, page=None):
-        """
-        Helper method for asserting that the correct translation link is displayed
-        :param display_region: str: either 'en' or 'cy'
-        :param user_journey: str
-        :param content: rendered HTML str
-        :param request_type: str
-        :param page: str
-        """
-        if display_region == 'cy':
-            lang = 'en'
-            link_text = 'English'
-        else:
-            lang = 'cy'
-            link_text = 'Cymraeg'
-
-        if not page:
-            link = '<a href="/' + lang + '/' + user_journey + '/" lang="' + lang + '" >' + link_text + '</a>'
-        elif not request_type:
-            link = '<a href="/' + lang + '/' + user_journey + '/' + page + \
-                   '/" lang="' + lang + '" >' + link_text + '</a>'
-        else:
-            link = '<a href="/' + lang + '/' + user_journey + '/' + request_type + '/' + page + \
-                   '/" lang="' + lang + '" >' + link_text + '</a>'
-
-        self.assertIn(link, content)
-
     def assert500Error(self, response, display_region, content, check_exit=False):
         """
         Helper method for asserting that the correct site logo is presented (english or welsh)

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -39,8 +39,7 @@ class TestHelpers(RHTestCase):
             self.assertEqual(response.status, 200)
             contents = str(await response.content.read())
             self.assertSiteLogo(display_region, contents)
-            self.assertCorrectTranslationLink(contents, display_region, self.user_journey,
-                                              self.request_type, 'timeout')
+
             if display_region == 'cy':
                 self.assertIn(self.content_common_timeout_cy, contents)
                 self.assertIn(self.content_request_timeout_error_cy, contents)
@@ -66,7 +65,6 @@ class TestHelpers(RHTestCase):
 
         self.assertNotExitButton(display_region, contents)
         self.assertSiteLogo(display_region, contents)
-        self.assertCorrectTranslationLink(contents, display_region, self.user_journey)
 
         if check_empty:
             self.assertCorrectHeadTitleTag(display_region, title_tag, contents, error=True)

--- a/tests/unit/test_error_handlers.py
+++ b/tests/unit/test_error_handlers.py
@@ -13,16 +13,6 @@ class TestErrorHandlers(RHTestCase):
         self.assertEqual(contents.count(b'input--text'), 1)
         self.assertIn(b'type="submit"', contents)
 
-    async def test_partial_path_redirects_to_index_cy(self):
-        with self.assertLogs('respondent-home', 'DEBUG') as cm:
-            response = await self.client.request('GET', str(self.get_start_cy).rstrip('/'))
-        self.assertLogEvent(cm, 'redirecting to index')
-        self.assertEqual(response.status, 200)
-        contents = await response.content.read()
-        self.assertIn('Start study', str(contents))
-        self.assertEqual(contents.count(b'input--text'), 1)
-        self.assertIn(b'type="submit"', contents)
-
     async def test_404_renders_template(self):
         response = await self.client.request('GET', '/unknown-path')
         self.assertEqual(response.status, 404)

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -44,7 +44,6 @@ class TestStartHandlers(TestHelpers):
         self.assertEqual(response.status, 200)
         contents = str(await response.content.read())
         self.assertSiteLogo('en', contents)
-        self.assertIn('<a href="/cy/start/" lang="cy" >Cymraeg</a>', contents)
         self.assertMessagePanel(BAD_CODE_MSG, contents)
 
     async def test_post_start_invalid_text_url_ew(self):
@@ -60,7 +59,6 @@ class TestStartHandlers(TestHelpers):
         self.assertEqual(response.status, 200)
         contents = str(await response.content.read())
         self.assertSiteLogo('en', contents)
-        self.assertIn('<a href="/cy/start/" lang="cy" >Cymraeg</a>', contents)
         self.assertMessagePanel(INVALID_CODE_MSG, contents)
 
     async def test_post_start_invalid_text_random_ew(self):
@@ -76,7 +74,6 @@ class TestStartHandlers(TestHelpers):
         self.assertEqual(response.status, 200)
         contents = str(await response.content.read())
         self.assertSiteLogo('en', contents)
-        self.assertIn('<a href="/cy/start/" lang="cy" >Cymraeg</a>', contents)
         self.assertMessagePanel(INVALID_CODE_MSG, contents)
 
     async def test_post_start_uac_closed_ew_w(self):
@@ -148,18 +145,6 @@ class TestStartHandlers(TestHelpers):
         self.assertLogEvent(cm, 'invalid access code entered')
         self.check_content_start('en', str(await response.content.read()), check_error=True)
 
-    async def test_post_start_get_uac_404_cy(self):
-        with aioresponses(passthrough=[str(self.server._root)]) as mocked:
-            mocked.get(self.eq_launch_url_cy, status=404)
-            with self.assertLogs('respondent-home', 'WARN') as cm:
-                response = await self.client.request('POST',
-                                                     self.post_start_cy,
-                                                     data=self.start_data_valid)
-            self.assertLogEvent(cm, 'attempt to use an invalid access code', client_ip=None)
-        self.assertEqual(response.status, 401)
-        self.assertLogEvent(cm, 'invalid access code entered')
-        self.check_content_start('cy', str(await response.content.read()), check_error=True)
-
     def test_uac_hash(self):
         # Given some post data
         post_data = {'uac': 'w4nw wpph jjpt p7fn', 'action[save_continue]': ''}
@@ -198,19 +183,6 @@ class TestStartHandlers(TestHelpers):
             self.assertIn(self.content_signed_out_page_title_en, contents)
             self.assertIn(self.content_signed_out_title_en, contents)
             self.assertSiteLogo('en', contents)
-            self.assertIn('<a href="/cy/signed-out/" lang="cy" >Cymraeg</a>', contents)
-
-    async def test_get_signed_out_cy(self):
-        with self.assertLogs('respondent-home', 'INFO') as cm:
-            response = await self.client.request('GET', self.get_signed_out_cy)
-            self.assertLogEvent(cm, "received GET on endpoint 'cy/signed-out'")
-            self.assertLogEvent(cm, "identity not previously remembered")
-            self.assertEqual(response.status, 200)
-            contents = str(await response.content.read())
-            self.assertIn(self.content_signed_out_page_title_cy, contents)
-            self.assertIn(self.content_signed_out_title_cy, contents)
-            self.assertSiteLogo('cy', contents)
-            self.assertIn('<a href="/en/signed-out/" lang="en" >English</a>', contents)
 
     async def test_post_start_for_receiptReceived_true_ew_e(self):
         with self.assertLogs('respondent-home', 'WARNING') as cm, aioresponses(
@@ -226,18 +198,3 @@ class TestStartHandlers(TestHelpers):
             contents = str(await response.content.read())
             self.assertSiteLogo('en', contents)
             self.assertIn(self.content_start_uac_already_used_en, contents)
-
-    async def test_post_start_for_receiptReceived_true_cy(self):
-        with self.assertLogs('respondent-home', 'WARNING') as cm, aioresponses(
-                passthrough=[str(self.server._root)]) as mocked:
-            mocked.get(self.eq_launch_url_cy, body='UAC_RECEIPTED', status=400)
-
-            response = await self.client.request('POST',
-                                                 self.post_start_cy,
-                                                 data=self.start_data_valid)
-
-            self.assertLogEvent(cm, "attempt to use receipted UAC")
-            self.assertEqual(response.status, 200)
-            contents = str(await response.content.read())
-            self.assertSiteLogo('cy', contents)
-            self.assertIn(self.content_start_uac_already_used_cy, contents)

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -26,11 +26,6 @@ class TestStartHandlers(TestHelpers):
                        '=http://localhost:9092/en/signed-out/&accountServiceUrl=http://localhost:9092/en/start' \
                        '/&languageCode=en'
 
-    eq_launch_url_cy = 'http://localhost:8071/eqLaunch' \
-                       '/54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c?accountServiceLogoutUrl' \
-                       '=http://localhost:9092/cy/signed-out/&accountServiceUrl=http://localhost:9092/cy/start' \
-                       '/&languageCode=cy'
-
     async def test_post_start_invalid_blank_ew(self):
         form_data = self.start_data_valid.copy()
         form_data['uac'] = ''


### PR DESCRIPTION
# Motivation and Context
No Welsh routing

# What has changed
Removed cy from allowed paths, hacked out Translation option.  Fixed tests to cope with this

This was a minimal change, take 2.  The ticket leaves RH-UI even more yukky, with lots of 

if display_region = 'cy:

code still in it and Welsh templates,  they are now unused.

# How to Test
In you env with other bits from ticket, does it work as expected can you navigate to .../cy/start

# Links
[<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):](https://trello.com/c/KadaIply/322-rh-english-only-routing8)