### PR TITLE
Temporarily revert dockerfile until permission issues are fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,11 @@
-FROM europe-west2-docker.pkg.dev/ons-ci-rm/docker/python-pipenv:latest as build
-
-ENV PIPENV_VENV_IN_PROJECT=1
+FROM python:3.10.4-slim
 
 WORKDIR /app
-COPY Pipfile* /app
-
-RUN /root/.local/bin/pipenv sync
-
-FROM python:3.10.6-slim@sha256:ddfe4839f1516d0484944e07ea22200ede3d48828ecbf1f68eec1a9a06b79406
-
+COPY . /app
+EXPOSE 9092
+RUN pip3 install pipenv && pipenv install --deploy --system
 RUN groupadd -g 984 respondenthome && \
     useradd -r -u 984 -g respondenthome respondenthome
-WORKDIR /app
-RUN mkdir -v /app/venv && chown respondenthome:respondenthome /app/venv
-COPY --chown=respondenthome:respondenthome --from=build /app/.venv/ /app/venv/
-COPY --chown=respondenthome:respondenthome . /app
-
-EXPOSE 9092
-
 USER respondenthome
-
-ENTRYPOINT ["/app/venv/bin/python"]
+ENTRYPOINT ["python3"]
 CMD ["run.py"]


### PR DESCRIPTION
# Motivation and Context
The concourse build job does not yet have permission to access the production GCR, causing the build to fail and blocking other PRs

# What has changed
Revert docker file until permissions are fixed