### PR TITLE
Load template error out

### DIFF
--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd "${DIR}"/.. || exit
+cd "${DIR}"/..
 
 DESIGN_SYSTEM_VERSION="55.1.0"
 

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="55.sdfdsf1.0"
+DESIGN_SYSTEM_VERSION="55.1.0"
 
 TEMP_DIR=$(mktemp -d)
 

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="55.1.0"
+DESIGN_SYSTEM_VERSION="55.sdfdsf1.0"
 
 TEMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When running in concourse, the load templates task has failed silently without us realising, leaving the rh ui build task to complete "successfully".

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Adding ```set -e``` to the load templates script so that if an error happens, it exits with an error.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
My steps to test this were:
Edit load-templates script to point to a design system version doesn't exist (see commit history on this branch)
Point my concourse to pull from this branch
Check that the load template task failed
Run again with the proper design system to check it passes successfully.

Let me know if you want me to show you it having failed and passed in my concourse env.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/oG3gCJ6z/392-fix-rh-ui-load-template-concourse-task
# Screenshots (if appropriate):