### PR TITLE
Fix 508 replace welsh url

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -44,7 +44,6 @@ class BaseConfig:
 
     DOMAIN_URL_PROTOCOL = env('DOMAIN_URL_PROTOCOL', default='https://')
     DOMAIN_URL_EN = env('DOMAIN_URL_EN')
-    DOMAIN_URL_CY = env('DOMAIN_URL_CY')
 
     ACCOUNT_SERVICE_URL = env('ACCOUNT_SERVICE_URL')
     EQ_URL = env('EQ_URL')
@@ -86,7 +85,6 @@ class DevelopmentConfig:
 
     DOMAIN_URL_PROTOCOL = 'http://'
     DOMAIN_URL_EN = env.str('DOMAIN_URL_EN', default='localhost:9092')
-    DOMAIN_URL_CY = env.str('DOMAIN_URL_CY', default='localhost:9092')
 
     ACCOUNT_SERVICE_URL = env.str('ACCOUNT_SERVICE_URL',
                                   default='http://localhost:9092')
@@ -126,7 +124,6 @@ class TestingConfig:
 
     DOMAIN_URL_PROTOCOL = 'http://'
     DOMAIN_URL_EN = 'localhost:9092'
-    DOMAIN_URL_CY = 'localhost:9092'
 
     ACCOUNT_SERVICE_URL = 'http://localhost:9092'
     EQ_URL = 'http://localhost:5000'

--- a/app/config.py
+++ b/app/config.py
@@ -84,7 +84,8 @@ class DevelopmentConfig:
     EXT_LOG_LEVEL = env('EXT_LOG_LEVEL', default='INFO')
 
     DOMAIN_URL_PROTOCOL = 'http://'
-    DOMAIN_URL_EN = env.str('DOMAIN_URL_EN', default='localhost:9092') # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
+    # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
+    DOMAIN_URL_EN = env.str('DOMAIN_URL_EN', default='localhost:9092')
 
     ACCOUNT_SERVICE_URL = env.str('ACCOUNT_SERVICE_URL',
                                   default='http://localhost:9092')
@@ -123,7 +124,7 @@ class TestingConfig:
     EXT_LOG_LEVEL = 'DEBUG'
 
     DOMAIN_URL_PROTOCOL = 'http://'
-    DOMAIN_URL_EN = 'localhost:9092' # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
+    DOMAIN_URL_EN = 'localhost:9092'  # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
 
     ACCOUNT_SERVICE_URL = 'http://localhost:9092'
     EQ_URL = 'http://localhost:5000'

--- a/app/config.py
+++ b/app/config.py
@@ -43,7 +43,7 @@ class BaseConfig:
     EXT_LOG_LEVEL = env('EXT_LOG_LEVEL')
 
     DOMAIN_URL_PROTOCOL = env('DOMAIN_URL_PROTOCOL', default='https://')
-    DOMAIN_URL_EN = env('DOMAIN_URL_EN')
+    DOMAIN_URL_EN = env('DOMAIN_URL_EN')  # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
 
     ACCOUNT_SERVICE_URL = env('ACCOUNT_SERVICE_URL')
     EQ_URL = env('EQ_URL')
@@ -84,7 +84,7 @@ class DevelopmentConfig:
     EXT_LOG_LEVEL = env('EXT_LOG_LEVEL', default='INFO')
 
     DOMAIN_URL_PROTOCOL = 'http://'
-    DOMAIN_URL_EN = env.str('DOMAIN_URL_EN', default='localhost:9092')
+    DOMAIN_URL_EN = env.str('DOMAIN_URL_EN', default='localhost:9092') # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
 
     ACCOUNT_SERVICE_URL = env.str('ACCOUNT_SERVICE_URL',
                                   default='http://localhost:9092')
@@ -123,7 +123,7 @@ class TestingConfig:
     EXT_LOG_LEVEL = 'DEBUG'
 
     DOMAIN_URL_PROTOCOL = 'http://'
-    DOMAIN_URL_EN = 'localhost:9092'
+    DOMAIN_URL_EN = 'localhost:9092' # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
 
     ACCOUNT_SERVICE_URL = 'http://localhost:9092'
     EQ_URL = 'http://localhost:5000'

--- a/app/domains.py
+++ b/app/domains.py
@@ -1,8 +1,6 @@
 async def domain_processor(request):
     domain_protocol = request.app['DOMAIN_URL_PROTOCOL']
     domain_en = request.app['DOMAIN_URL_EN']
-    domain_cy = request.app['DOMAIN_URL_CY']
     return {'domain_url_en': domain_protocol + domain_en,
-            'domain_url_cy': domain_protocol + domain_cy,
             'site_name_en': request.app['SITE_NAME_EN'],
             'site_name_cy': request.app['SITE_NAME_CY']}

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -238,12 +238,10 @@ def check_display_region(request):
 
     domain_url_en = request.app['DOMAIN_URL_PROTOCOL'] + request.app[
         'DOMAIN_URL_EN']
-    domain_url_cy = request.app['DOMAIN_URL_PROTOCOL'] + request.app[
-        'DOMAIN_URL_CY']
+
 
     base_attributes = {
         'domain_url_en': domain_url_en,
-        'domain_url_cy': domain_url_cy,
         'page_url': View.gen_page_url(request)
     }
 

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -239,7 +239,6 @@ def check_display_region(request):
     domain_url_en = request.app['DOMAIN_URL_PROTOCOL'] + request.app[
         'DOMAIN_URL_EN']
 
-
     base_attributes = {
         'domain_url_en': domain_url_en,
         'page_url': View.gen_page_url(request)

--- a/app/handlers.py
+++ b/app/handlers.py
@@ -43,7 +43,7 @@ class SignedOut(View):
         }
 
 
-@static_routes.view('/cookies/')
+@static_routes.view(r'/' + View.valid_display_regions + '/cookies/')
 class Cookies(View):
     @aiohttp_jinja2.template('cookies.html')
     async def get(self, request):
@@ -52,7 +52,7 @@ class Cookies(View):
         }
 
 
-@static_routes.view('/privacy-and-data-protection/')
+@static_routes.view(r'/' + View.valid_display_regions + '/privacy-and-data-protection/')
 class PrivacyAndDataProtection(View):
     @aiohttp_jinja2.template('privacy-and-data-protection.html')
     async def get(self, request):

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -38,7 +38,7 @@
                 'itemsList': [
                     {
                         'text': 'PLACEHOLDER WELSH Cwcis',
-                        'url': domain_url_cy + '/cookies/'
+                        'url': domain_url_en + '/cy/cookies/'
                     },
                     {
                         'text': 'PLACEHOLDER WELSH Datganiad hygyrchedd',
@@ -46,7 +46,7 @@
                     },
                     {
                         'text': 'PLACEHOLDER WELSH Preifatrwydd a diogelu data',
-                        'url': domain_url_cy + '/privacy-and-data-protection/'
+                        'url': domain_url_en + '/cy/privacy-and-data-protection/'
                     }
                 ]
             }
@@ -126,9 +126,9 @@
 {#    {{#}
 {#        onsCookiesBanner({#}
 {#            'statementTitle': 'PLACEHOLDER WELSH Dywedwch wrthym a ydych yn derbyn cwcis',#}
-{#            'statementText': "PLACEHOLDER WELSH Rydym ni’n defnyddio <a href='" + domain_url_cy + "/cookies/" + "'>cwcis i gasglu gwybodaeth</a> am y ffordd rydych chi’n defnyddio cy.ons.gov.uk. Rydym ni’n defnyddio’r wybodaeth hon i sicrhau bod y wefan yn gweithio cystal â phosibl ac i wella ein gwasanaethau.",#}
-{#            'confirmationText': 'PLACEHOLDER WELSH Rydych chi wedi derbyn yr holl gwcis. Gallwch chi <a href="' + domain_url_cy + '/cookies/' + '">newid eich dewisiadau o ran cwcis</a> ar unrhyw adeg.',#}
-{#            'secondaryButtonUrl': domain_url_cy + '/cookies/',#}
+{#            'statementText': "PLACEHOLDER WELSH Rydym ni’n defnyddio <a href='" + domain_url_en + "/cy/cookies/" + "'>cwcis i gasglu gwybodaeth</a> am y ffordd rydych chi’n defnyddio cy.ons.gov.uk. Rydym ni’n defnyddio’r wybodaeth hon i sicrhau bod y wefan yn gweithio cystal â phosibl ac i wella ein gwasanaethau.",#}
+{#            'confirmationText': 'PLACEHOLDER WELSH Rydych chi wedi derbyn yr holl gwcis. Gallwch chi <a href="' + domain_url_en + '/cy/cookies/' + '">newid eich dewisiadau o ran cwcis</a> ar unrhyw adeg.',#}
+{#            'secondaryButtonUrl': domain_url_en + '/cy/cookies/',#}
 {#            'primaryButtonText': "PLACEHOLDER WELSH Derbyn yr holl gwcis",#}
 {#            'secondaryButtonText': "PLACEHOLDER WELSH Gosod dewisiadau o ran cwcis",#}
 {#            'confirmationButtonText': 'PLACEHOLDER WELSH Cuddio hwn',#}

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -36,7 +36,7 @@
                 'itemsList': [
                     {
                         'text': 'Cookies',
-                        'url': domain_url_en + '/cookies/'
+                        'url': domain_url_en + '/en/cookies/'
                     },
                     {
                         'text': 'Accessibility statement',
@@ -44,7 +44,7 @@
                     },
                     {
                         'text': 'Privacy and data protection',
-                        'url': domain_url_en + '/privacy-and-data-protection/'
+                        'url': domain_url_en + '/en/privacy-and-data-protection/'
                     },
                 ]
             }
@@ -101,8 +101,8 @@
     {%- from 'components/cookies-banner/_macro.njk' import onsCookiesBanner -%}
     {{ onsCookiesBanner({
             "statementTitle": 'Tell us whether you accept cookies',
-            "statementText": 'We use <a href="' + domain_url_en + '/cookies/' + '">cookies to collect information</a> about how you use start.surveys.ons.gov.uk. We use this information to make the website work as well as possible and improve our services.',
-            "confirmationText": 'You’ve accepted all cookies. You can <a href="' + domain_url_en + '/cookies/' + '">change your cookie preferences</a> at any time.',
+            "statementText": 'We use <a href="' + domain_url_en + '/en/cookies/' + '">cookies to collect information</a> about how you use start.surveys.ons.gov.uk. We use this information to make the website work as well as possible and improve our services.',
+            "confirmationText": 'You’ve accepted all cookies. You can <a href="' + domain_url_en + '/en/cookies/' + '">change your cookie preferences</a> at any time.',
             "secondaryButtonUrl": domain_url_en + '/cookies/'
         }) }}
 {%- endblock -%}

--- a/app/templates/start-too-many-requests.html
+++ b/app/templates/start-too-many-requests.html
@@ -7,7 +7,7 @@
 {%- if display_region == 'cy' -%}
     {%- set breadcrumb_items = [
                 {
-                    "url": domain_url_cy,
+                    "url": domain_url_en + '/cy',
                     "text": 'Hafan'
                 }
             ]

--- a/app/utils.py
+++ b/app/utils.py
@@ -43,8 +43,9 @@ class View:
 
     @staticmethod
     def get_campaign_site_link(request, display_region, requested_link):
-        base_en = request.app['DOMAIN_URL_PROTOCOL'] + request.app['DOMAIN_URL_EN']
-        base_cy = base_en + '/'
+        # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
+        base_en = request.app['DOMAIN_URL_PROTOCOL'] + request.app['DOMAIN_URL_EN'] + '/en'
+        base_cy = request.app['DOMAIN_URL_PROTOCOL'] + request.app['DOMAIN_URL_EN'] + '/cy'
 
         link = '/'
 
@@ -60,8 +61,7 @@ class View:
                 link = 'https://www.ons.gov.uk/aboutus/contactus/surveyenquiries'
         elif requested_link == 'privacy':
             if display_region == 'cy':
-                # PLACEHOLDER WELSH
-                link = base_cy + '/preifatrwydd-a-diogelu-data/'
+                link = base_cy + '/privacy-and-data-protection/'
             else:
                 link = base_en + '/privacy-and-data-protection/'
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -44,7 +44,7 @@ class View:
     @staticmethod
     def get_campaign_site_link(request, display_region, requested_link):
         base_en = request.app['DOMAIN_URL_PROTOCOL'] + request.app['DOMAIN_URL_EN']
-        base_cy = request.app['DOMAIN_URL_PROTOCOL'] + request.app['DOMAIN_URL_CY']
+        base_cy = base_en + '/'
 
         link = '/'
 

--- a/kubernetes/dev.yml
+++ b/kubernetes/dev.yml
@@ -44,7 +44,7 @@ spec:
         - name: http-server
           containerPort: 9092
         env:
-        - name: DOMAIN_URL_EN
+        - name: DOMAIN_URL_EN # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
           valueFrom:
             configMapKeyRef:
               name: domains

--- a/kubernetes/dev.yml
+++ b/kubernetes/dev.yml
@@ -49,11 +49,6 @@ spec:
             configMapKeyRef:
               name: domains
               key: en-host
-        - name: DOMAIN_URL_CY
-          valueFrom:
-            configMapKeyRef:
-              name: domains
-              key: cy-host
         - name: ADDRESS_INDEX_SVC_URL
           valueFrom:
             configMapKeyRef:

--- a/tests/test_data/local.env
+++ b/tests/test_data/local.env
@@ -2,7 +2,6 @@ PORT=9092
 APP_SETTINGS=DevelopmentConfig
 
 DOMAIN_URL_EN=http://localhost:9092
-DOMAIN_URL_CY=http://localhost:9092
 ACCOUNT_SERVICE_URL=http://localhost:9092
 RHSVC_PASSWORD=secret
 RHSVC_URL=http://localhost:8071

--- a/tests/test_data/local.env
+++ b/tests/test_data/local.env
@@ -1,7 +1,7 @@
 PORT=9092
 APP_SETTINGS=DevelopmentConfig
 
-DOMAIN_URL_EN=http://localhost:9092
+DOMAIN_URL_EN=http://localhost:9092 # DOMAIN_URL_EN needs to be renamed to DOMAIN_URL
 ACCOUNT_SERVICE_URL=http://localhost:9092
 RHSVC_PASSWORD=secret
 RHSVC_URL=http://localhost:8071


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fix to "508-replace-welsh-urls", which didn't pass smoke testing.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

All reference to DOMAIN_URL_CY has been removed.
Both English and Welsh urls are using DOMAIN_URL_EN, this needs to be changed to DOMAIN_URL, added comments and a  new card for that.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

Test on GCP, rather than localhost.

Run the UI and check if the Cookies and Privacy and data protection links direct to the correct pages on /en and /cy.

(all pages will be in English, this will be fixed under another card:
https://trello.com/c/WHXv2fOD/551-rhui-add-welsh-translations-for-cookies-and-privacy-and-data-protection-templates-5)

Removing the DOMAIN_URL_CY in the test environment didn't change the result of the tests.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

https://trello.com/c/WysU6Gh1/508-welsh-rh-ui-page-links-pointing-to-dev-urls

The pull request that didn't pass smoke testing:
https://github.com/ONSdigital/sdc-int-rh-ui/pull/70

# Screenshots (if appropriate):