### PR TITLE
492 Fix RH UI local build image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ RM_TOOLS_REPO_URL = https://github.com/ONSdigital/rm-tools.git
 build: test docker-build
 
 docker-build:
-	docker build -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/rh-ui .
+	docker build -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/sdc-int-rh-ui .
 
 install:
 	pipenv install --dev


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The RH UI image name was not consistent, update it to match the CI and release image names.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Fix the local build image name

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Does the local build image name match the manifests/pipelines/docker dev?

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/RXpOOBm1/492-build-preprod-8