### PR TITLE
506-fix-links-on-cookies-banner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - docker network create ssdcrmdockerdev_default
 
 install:
-  - pip install -U pipenv
+  - pip install -U pipenv==v2022.11.11
 
 script:
   - make test

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -110,29 +110,14 @@
 {%- endblock -%}
 
 {%- block preHeader -%}
+    {% set cookiesPageURL = domain_url_en + '/cy/cookies/' %}
 
     {%- from 'components/cookies-banner/_macro.njk' import onsCookiesBanner -%}
-    {{
-        onsCookiesBanner({
-            'lang': 'cy'
-        })
-    }}
+    {{ onsCookiesBanner({
+        'lang': 'cy',
+        'settingsLinkURL': cookiesPageURL,
+        'statementText': '<p>Ffeiliau bach a gaiff eu storio ar eich dyfais pan fyddwch yn mynd ar wefan yw cwcis. Rydym ni’n defnyddio rhai cwcis hanfodol i wneud i’r wefan hon weithio.</p><p>Hoffem osod <a href="' + cookiesPageURL + '">cwcis ychwanegol</a> er mwyn cofio eich gosodiadau a deall sut rydych chi’n defnyddio’r wefan. Mae hyn yn ein helpu ni i wella ein gwasanaethau.</p>',
+        'preferencesText': 'Gallwch chi <a href="' + cookiesPageURL + '">newid eich dewisiadau o ran cwcis</a> ar unrhyw adeg.'
+        }) }}
 {%- endblock -%}
 
-{#TODO: PLACEHOLDER WELSH  Old below: But we're calling design system, so should be able to read theirs. Below did little as different vars now #}
-{#{%- block preHeader -%}#}
-{##}
-{#    {%- from 'components/cookies-banner/_macro.njk' import onsCookiesBanner -%}#}
-{#    {{#}
-{#        onsCookiesBanner({#}
-{#            'statementTitle': 'PLACEHOLDER WELSH Dywedwch wrthym a ydych yn derbyn cwcis',#}
-{#            'statementText': "PLACEHOLDER WELSH Rydym ni’n defnyddio <a href='" + domain_url_en + "/cy/cookies/" + "'>cwcis i gasglu gwybodaeth</a> am y ffordd rydych chi’n defnyddio cy.ons.gov.uk. Rydym ni’n defnyddio’r wybodaeth hon i sicrhau bod y wefan yn gweithio cystal â phosibl ac i wella ein gwasanaethau.",#}
-{#            'confirmationText': 'PLACEHOLDER WELSH Rydych chi wedi derbyn yr holl gwcis. Gallwch chi <a href="' + domain_url_en + '/cy/cookies/' + '">newid eich dewisiadau o ran cwcis</a> ar unrhyw adeg.',#}
-{#            'secondaryButtonUrl': domain_url_en + '/cy/cookies/',#}
-{#            'primaryButtonText': "PLACEHOLDER WELSH Derbyn yr holl gwcis",#}
-{#            'secondaryButtonText': "PLACEHOLDER WELSH Gosod dewisiadau o ran cwcis",#}
-{#            'confirmationButtonText': 'PLACEHOLDER WELSH Cuddio hwn',#}
-{#            'lang': 'cy'#}
-{#        })#}
-{#    }}#}
-{#{%- endblock -%}#}

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -97,12 +97,13 @@
 } -%}
 
 {%- block preHeader -%}
+    {% set cookiesPageURL = domain_url_en + '/en/cookies/' %}
 
     {%- from 'components/cookies-banner/_macro.njk' import onsCookiesBanner -%}
     {{ onsCookiesBanner({
-            "statementTitle": 'Tell us whether you accept cookies',
-            "statementText": 'We use <a href="' + domain_url_en + '/en/cookies/' + '">cookies to collect information</a> about how you use start.surveys.ons.gov.uk. We use this information to make the website work as well as possible and improve our services.',
-            "confirmationText": 'You’ve accepted all cookies. You can <a href="' + domain_url_en + '/en/cookies/' + '">change your cookie preferences</a> at any time.',
-            "secondaryButtonUrl": domain_url_en + 'en/cookies/'
+        'lang': 'en',
+        'settingsLinkURL': cookiesPageURL,
+        'statementText': '<p>Cookies are small files stored on your device when you visit a website. We use some essential cookies to make this website work.</p><p>We would like to set <a href="' + cookiesPageURL + '">additional cookies</a> to remember your settings and understand how you use the site. This helps us to improve our services. </p>',
+        'preferencesText':  'You can <a href="' + cookiesPageURL + '">change your cookie preferences</a> at any time.'
         }) }}
 {%- endblock -%}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixed the links to the cookies banner to point to /en/cookies and /cy/cookies

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

Overwritten the default link to the cookies page in the cookiesBanner design pattern

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

No changes

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

Trello card: 
https://trello.com/c/Y0IW9jBu/560-rh-cookies-fix-3-broken-links

# Screenshots (if appropriate):