### PR TITLE
632 Make domain protocol configurable for dev config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -81,7 +81,7 @@ class DevelopmentConfig(BaseConfig):
     LOG_LEVEL = env('LOG_LEVEL', default='INFO')
     EXT_LOG_LEVEL = env('EXT_LOG_LEVEL', default='INFO')
 
-    DOMAIN_URL_PROTOCOL = 'http://'
+    DOMAIN_URL_PROTOCOL = env.str('DOMAIN_URL_PROTOCOL', default='http://')
     DOMAIN_URL = env.str('DOMAIN_URL', default='localhost:9092')
 
     EQ_URL = env.str('EQ_URL', default='http://localhost:5000')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Our cookies return link was not working. The `strict-origin-when-cross-origin` security header was correctly preventing movement from HTTPS to HTTP between pages, however, this was then preventing the 'return' link from rendering on our cookies page due to there being [no referrer in the JS we are using](https://github.com/ONSdigital/design-system/blob/main/src/js/cookies-settings.js#L95)

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Allow environments that leverage HTTPS which use the `DevelopmentConfig` to override the `DOMAIN_URL_PROTOCOL` with HTTPS when needed

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run in your environment and set the `DOMAIN_URL_PROTOCOL`to `HTTPS` in your configuration. This should allow the return link to render correctly.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/hJORBKUA