### PR TITLE
618 improve rh UI navigation links

### DIFF
--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -28,6 +28,11 @@
                         'target': '_blank'
                     },
                     {
+                        'text': 'PLACEHOLDER WELSH Datganiad hygyrchedd',
+                        'url': 'https://cy.ons.gov.uk/help/accessibility',
+                        'target': '_blank'
+                    },
+                    {
                         'text': 'PLACEHOLDER WELSH Cysylltu â ni',
                         'url': 'https://cy.ons.gov.uk/aboutus/contactus/surveyenquiries',
                         'target': '_blank'
@@ -41,11 +46,6 @@
                     {
                         'text': 'PLACEHOLDER WELSH Cwcis',
                         'url': domain_url + '/cy/cookies/',
-                    },
-                    {
-                        'text': 'PLACEHOLDER WELSH Datganiad hygyrchedd',
-                        'url': 'https://cy.ons.gov.uk/help/accessibility',
-                        'target': '_blank'
                     },
                     {
                         'text': 'PLACEHOLDER WELSH Preifatrwydd a diogelu data',

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -16,6 +16,7 @@
 {%- endif -%}
 
 {%- set footer_content = {
+        'newTabWarning': 'PLACEHOLDER WELSH The following links open in a new tab',
         'lang': 'cy',
         'crest': true,
         'rows': [
@@ -23,11 +24,13 @@
                 'itemsList': [
                     {
                         'text': 'PLACEHOLDER WELSH About ONS studies',
-                        'url': 'https://cy.ons.gov.uk/surveys/informationforhouseholdsandindividuals'
+                        'url': 'https://cy.ons.gov.uk/surveys/informationforhouseholdsandindividuals',
+                        'target': '_blank'
                     },
                     {
                         'text': 'PLACEHOLDER WELSH Cysylltu â ni',
-                        'url': 'https://cy.ons.gov.uk/aboutus/contactus/surveyenquiries'
+                        'url': 'https://cy.ons.gov.uk/aboutus/contactus/surveyenquiries',
+                        'target': '_blank'
                     }
                 ]
             }
@@ -37,15 +40,18 @@
                 'itemsList': [
                     {
                         'text': 'PLACEHOLDER WELSH Cwcis',
-                        'url': domain_url + '/cy/cookies/'
+                        'url': domain_url + '/cy/cookies/',
+                        'target': '_blank'
                     },
                     {
                         'text': 'PLACEHOLDER WELSH Datganiad hygyrchedd',
-                        'url': 'https://cy.ons.gov.uk/help/accessibility'
+                        'url': 'https://cy.ons.gov.uk/help/accessibility',
+                        'target': '_blank'
                     },
                     {
                         'text': 'PLACEHOLDER WELSH Preifatrwydd a diogelu data',
-                        'url': domain_url + '/cy/privacy-and-data-protection/'
+                        'url': domain_url + '/cy/privacy-and-data-protection/',
+                        'target': '_blank'
                     }
                 ]
             }
@@ -81,7 +87,7 @@
     'language': language,
     'header': {
         'language': 'cy',
-        'orgLogoHref': domain_url + '/cy/start/',
+        'orgLogoHref': 'https://cy.ons.gov.uk/',
         'title': site_name_cy
     },
     'signoutButton': signout_button_value,

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -41,7 +41,6 @@
                     {
                         'text': 'PLACEHOLDER WELSH Cwcis',
                         'url': domain_url + '/cy/cookies/',
-                        'target': '_blank'
                     },
                     {
                         'text': 'PLACEHOLDER WELSH Datganiad hygyrchedd',
@@ -51,7 +50,6 @@
                     {
                         'text': 'PLACEHOLDER WELSH Preifatrwydd a diogelu data',
                         'url': domain_url + '/cy/privacy-and-data-protection/',
-                        'target': '_blank'
                     }
                 ]
             }

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -16,17 +16,20 @@
 {%- endif -%}
 
 {%- set footer_content = {
+        'newTabWarning': 'The following links open in a new tab',
         'crest': true,
         'rows': [
             {
                 'itemsList': [
                     {
                         'text': 'About ONS studies',
-                        'url': 'https://www.ons.gov.uk/surveys/informationforhouseholdsandindividuals'
+                        'url': 'https://www.ons.gov.uk/surveys/informationforhouseholdsandindividuals',
+                        'target': '_blank'
                     },
                     {
                         'text': 'Contact us',
-                        'url': 'https://www.ons.gov.uk/aboutus/contactus/surveyenquiries'
+                        'url': 'https://www.ons.gov.uk/aboutus/contactus/surveyenquiries',
+                        'target': '_blank'
                     }
                 ]
             }
@@ -36,15 +39,18 @@
                 'itemsList': [
                     {
                         'text': 'Cookies',
-                        'url': domain_url + '/en/cookies/'
+                        'url': domain_url + '/en/cookies/',
+                        'target': '_blank'
                     },
                     {
                         'text': 'Accessibility statement',
-                        'url': 'https://www.ons.gov.uk/help/accessibility'
+                        'url': 'https://www.ons.gov.uk/help/accessibility',
+                        'target': '_blank'
                     },
                     {
                         'text': 'Privacy and data protection',
-                        'url': domain_url + '/en/privacy-and-data-protection/'
+                        'url': domain_url + '/en/privacy-and-data-protection/',
+                        'target': '_blank'
                     },
                 ]
             }
@@ -77,7 +83,7 @@
 {%- set pageConfig = {
     'title': page_title_value,
     'header': {
-        'orgLogoHref': domain_url + '/en/start/',
+        'orgLogoHref': 'http://www.ons.gov.uk/',
         'title': site_name_en
     },
     'signoutButton': signout_button_value,

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -27,6 +27,11 @@
                         'target': '_blank'
                     },
                     {
+                        'text': 'Accessibility statement',
+                        'url': 'https://www.ons.gov.uk/help/accessibility',
+                        'target': '_blank'
+                    },
+                    {
                         'text': 'Contact us',
                         'url': 'https://www.ons.gov.uk/aboutus/contactus/surveyenquiries',
                         'target': '_blank'
@@ -42,14 +47,9 @@
                         'url': domain_url + '/en/cookies/',
                     },
                     {
-                        'text': 'Accessibility statement',
-                        'url': 'https://www.ons.gov.uk/help/accessibility',
-                        'target': '_blank'
-                    },
-                    {
                         'text': 'Privacy and data protection',
                         'url': domain_url + '/en/privacy-and-data-protection/',
-                    },
+                    }
                 ]
             }
         ],

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -83,7 +83,7 @@
 {%- set pageConfig = {
     'title': page_title_value,
     'header': {
-        'orgLogoHref': 'http://www.ons.gov.uk/',
+        'orgLogoHref': 'https://www.ons.gov.uk/',
         'title': site_name_en
     },
     'signoutButton': signout_button_value,

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -40,7 +40,6 @@
                     {
                         'text': 'Cookies',
                         'url': domain_url + '/en/cookies/',
-                        'target': '_blank'
                     },
                     {
                         'text': 'Accessibility statement',
@@ -50,7 +49,6 @@
                     {
                         'text': 'Privacy and data protection',
                         'url': domain_url + '/en/privacy-and-data-protection/',
-                        'target': '_blank'
                     },
                 ]
             }

--- a/app/templates/cookies.html
+++ b/app/templates/cookies.html
@@ -5,10 +5,23 @@
 {% from "components/collapsible/_macro.njk" import onsCollapsible %}
 {% from "components/table/_macro.njk" import onsTable %}
 {% from "components/lists/_macro.njk" import onsList %}
+{% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 
 {% set page_title = _("Cookies on start.surveys.ons.gov.uk") %}
 
 {%- block main -%}
+    {{
+        onsBreadcrumbs({
+            "ariaLabel": 'Back',
+            "itemsList": [
+                {
+                    "url": domain_url + '/en/start/',
+                    "id": "back",
+                    "text": 'Back',
+                }
+            ]
+        })
+    }}
 
     {% call onsPanel({
             "classes": "ons-u-mb-s ons-u-d-no ons-cookies-confirmation-message",

--- a/app/templates/privacy-and-data-protection.html
+++ b/app/templates/privacy-and-data-protection.html
@@ -1,9 +1,22 @@
 {%- extends 'base-' + display_region + '.html' -%}
+{% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/lists/_macro.njk" import onsList %}
 
 {% set page_title = _("Privacy and data protection") %}
 
 {% block main %}
+    {{
+        onsBreadcrumbs({
+            "ariaLabel": 'Back',
+            "itemsList": [
+                {
+                    "url": domain_url + '/en/start/',
+                    "id": "back",
+                    "text": 'Back',
+                }
+            ]
+        })
+    }}
 
     <h1 class="ons-u-fs-xl">{{ _('Privacy and data protection') }}</h1>
 


### PR DESCRIPTION
# Motivation and Context
A few navigation links needed improving.

# What has changed
- The ONS logo at the top of the page now links to the ONS website (English links to English, Welsh to Welsh)
- All footer links now open in a new tab. Added a message to say this, matching the screenshots on the Trello card
- Added a navigation 'back' link to the cookies and privacy pages.  These link back to the survey start page.

# How to test?
Check the links are all there and work as they should.  Check against the examples on the Trello card.

# Links
https://trello.com/c/COqn5azz
