### PR TITLE
660 Allow tab to open for privacy and data protection links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ down:
 	./docker/rh-ui-stop.sh
 
 check:
-	pipenv check -i 51499 -i 51457 # Ignore issues with py from pytest and wheels from pipenv
+	pipenv check -i 51499 -i 51457  -i 52365 # Ignore issues with py from pytest and wheels from pipenv
 
 load_templates:
 	./scripts/load_templates.sh

--- a/app/templates/privacy-and-data-protection.html
+++ b/app/templates/privacy-and-data-protection.html
@@ -28,7 +28,7 @@
                 {
                     "text": _('recognise that you are sharing personal information with us and treat it as confidential, as directed
                         by the%(open_code_of_practice_link)s Code of Practice for Statistics%(close_link)s',
-                            open_code_of_practice_link = '<a href="%s">' % code_of_practice_link,
+                            open_code_of_practice_link = '<a href="%s", target="_blank">' % code_of_practice_link,
                             close_link='</a>')
                 },
                 {

--- a/app/templates/privacy-and-data-protection.html
+++ b/app/templates/privacy-and-data-protection.html
@@ -46,8 +46,8 @@
                         approved researchers%(close_link)s for statistical purposes only, subject to the same standards of
                         protection we apply (and according to the provisions of the Data Protection Legislation,
                         the Statistics and Registration Service Act 2007 and the Code of Practice for Statistics)',
-                        open_access_to_research_link='<a href="%s">' % access_to_research_link,
-                        open_approved_researchers_link='<a href="%s">' % approved_researchers_link,
+                        open_access_to_research_link='<a href="%s", target="_blank">' % access_to_research_link,
+                        open_approved_researchers_link='<a href="%s", target="_blank">' % approved_researchers_link,
                         close_link='</a>')
                 },
                 {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The links in the Privacy and Data Protection text need to open in a new tab, instead of in the same window.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Fixed tab opening
* Explicit ignore new vulnerability for now. This will be addressed in [this ticket](https://trello.com/c/KKsQZbrK)

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the affected links open in a new tab

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/1GAHY2Hw