### PR TITLE
Remove logout URL and set accout service URL to be base URL only

### DIFF
--- a/app/eq.py
+++ b/app/eq.py
@@ -56,25 +56,19 @@ class EqLaunch(object):
 
     @staticmethod
     def _url_path(uac_hash: str, display_region: str, app: Application):
-        account_service_url, account_service_log_out_url = EqLaunch._get_account_service_url_and_logout(app,
-                                                                                                        display_region)
+        account_service_url = EqLaunch._get_account_service_url(app,
+                                                                display_region)
         base = f'/eqLaunch/{uac_hash}'
         p1 = f'languageCode={display_region}'
         p2 = f'accountServiceUrl={account_service_url}'
-        p3 = f'accountServiceLogoutUrl={account_service_log_out_url}'
-        url = f'{base}?{p3}&{p2}&{p1}'
+        url = f'{base}?{p2}&{p1}'
         return url
 
     @staticmethod
-    def _get_account_service_url_and_logout(app: Application, display_region: str):
+    def _get_account_service_url(app: Application, display_region: str):
         domain_url_protocol = app['DOMAIN_URL_PROTOCOL']
         domain_url = app['DOMAIN_URL']
         url_path_prefix = app['URL_PATH_PREFIX']
-        url_display_region = '/' + display_region
-        save_and_exit_url = '/signed-out/'
-        start_url = '/start/'
-        account_service_url = f'{domain_url_protocol}{domain_url}{url_path_prefix}{url_display_region}{start_url}'
-        account_service_log_out_url = \
-            f'{domain_url_protocol}{domain_url}{url_path_prefix}{url_display_region}{save_and_exit_url}'
+        account_service_url = f'{domain_url_protocol}{domain_url}{url_path_prefix}'
 
-        return account_service_url, account_service_log_out_url
+        return account_service_url

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -324,11 +324,6 @@ class RHTestCase(AioHTTPTestCase):
         url_path_prefix = self.app['URL_PATH_PREFIX']
         return f'{account_svc_url}{url_path_prefix}/{display_region}/start/'
 
-    def get_full_account_service_logout_url(self, display_region):
-        account_svc_url = self.app['ACCOUNT_SERVICE_URL']
-        url_path_prefix = self.app['URL_PATH_PREFIX']
-        return f'{account_svc_url}{url_path_prefix}/{display_region}/signed-out/'
-
     async def asyncSetUp(self):
         # This section gets ugly if YAPF reformats it
         # yapf: disable
@@ -501,7 +496,6 @@ class RHTestCase(AioHTTPTestCase):
         }
 
         self.account_service_url = '/start/'
-        self.account_service_log_out_url = '/signed-out/'
 
         self.rhsvc_url = (
             f'{rh_svc_url}/eqLaunch/{self.uacHash}'

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -98,9 +98,8 @@ class TestHelpers(RHTestCase):
         base = self.rhsvc_url_get_launch_token
         p1 = 'languageCode=' + display_region
         p2 = 'accountServiceUrl=' + self.get_full_account_service_url(display_region)
-        p3 = 'accountServiceLogoutUrl=' + self.get_full_account_service_logout_url(display_region)
-        p4 = 'clientIP=None'
-        url = f'{base}?{p1}&{p2}&{p3}&{p4}'
+        p3 = 'clientIP=None'
+        url = f'{base}?{p1}&{p2}&{p3}'
         return url
 
     async def check_post_start_get_uac_error(self, post_start_url, display_region, status):

--- a/tests/unit/test_eq.py
+++ b/tests/unit/test_eq.py
@@ -28,8 +28,7 @@ class TestEq(TestHelpers):
             args = rh_svc.call_args.args
             self.assertEqual(args[0], data)
             self.assertEqual(args[1],
-                             '/eqLaunch/TEST_UAC_HASH?accountServiceLogoutUrl=httpdomain_urlurl_prefix/en/signed-out'
-                             '/&accountServiceUrl=httpdomain_urlurl_prefix/en/start/&languageCode=en')
+                             '/eqLaunch/TEST_UAC_HASH?accountServiceUrl=httpdomain_urlurl_prefix&languageCode=en')
 
     def test_call_eq(self):
         self.assertRaises(HTTPFound, EqLaunch.call_eq, 'eq_url_str', 'Test_token')

--- a/tests/unit/test_start_handlers.py
+++ b/tests/unit/test_start_handlers.py
@@ -12,14 +12,12 @@ attempts_retry_limit = 5
 class TestStartHandlers(TestHelpers):
     user_journey = 'start'
     eq_launch_url_en = 'http://localhost:8071/eqLaunch' \
-                       '/54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c?accountServiceLogoutUrl' \
-                       '=http://localhost:9092/en/signed-out/&accountServiceUrl=http://localhost:9092/en/start' \
-                       '/&languageCode=en'
+                       '/54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c' \
+                       '?accountServiceUrl=http://localhost:9092&languageCode=en'
 
     eq_launch_url_cy = 'http://localhost:8071/eqLaunch' \
-                       '/54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c?accountServiceLogoutUrl' \
-                       '=http://localhost:9092/cy/signed-out/&accountServiceUrl=http://localhost:9092/cy/start' \
-                       '/&languageCode=cy'
+                       '/54598f02da027026a584fd0bc7176de55a3e6472f4b3c74f68d0ae7be206e17c' \
+                       '?accountServiceUrl=http://localhost:9092&languageCode=cy'
 
     async def test_post_start_invalid_blank_ew(self):
         form_data = self.start_data_valid.copy()


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We send account_service_url=rh-ui-url/en/start to EQ. They then append /en/start/ for the save and resume redirection. This means it ends up as account_service_url=rh-ui-url/en/start/en/start.
We also want to remove the account_service_logout_url from the token we send to EQ.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed `account_service_logout_url` code and set base URL so it no longer has `/en or cy/start/`
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build this branch along with the RH service branch of the same name. Run ATs. If possible, push to your GCP env, and use a UAC from RH UI, get the eq token and decrypt it and check the `account_service_url` doesn't have `/en or cy/start/` and that it is also using HTTPS.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/HuqjtCkR/532-bug-defect-eq-save-resume-endpoint-account-service-url-3
# Screenshots (if appropriate):