### PR TITLE
Fix 739 RH UI remove signed out page leftovers 

### DIFF
--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -462,6 +462,9 @@ class RHTestCase(AioHTTPTestCase):
         self.get_start_cy = self.app.router['Start:get'].url_for(display_region='cy')
         self.post_start_cy = self.app.router['Start:post'].url_for(display_region='cy')
 
+        self.get_cookies_en = self.app.router['Cookies:get'].url_for(display_region='en')
+        self.get_cookies_cy = self.app.router['Cookies:get'].url_for(display_region='cy')
+
         self.get_privacy_en = self.app.router['PrivacyAndDataProtection:get'].url_for(display_region='en')
         self.get_privacy_cy = self.app.router['PrivacyAndDataProtection:get'].url_for(display_region='cy')
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

I somehow merged branch `739-rh-ui-remove-signed-out-page-leftovers` to main without squashing, and to make it worse I accidentally removed a test helper and Travis didn't stop me from merging so it's going to fail in the pipeline..

The goal of this branch is to put the test helper back and leave an explanation for the unsquashed commits

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
Original Trello card:
https://trello.com/c/zORAk8Wo/739-rh-ui-remove-signed-out-page-leftovers-kp

# Screenshots (if appropriate):