### PR TITLE
943 google analytics implement code snippets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - docker network create ssdcrmdockerdev_default
 
 install:
-  - pip install -U pipenv
+  - pip install -U pipenv==v2023.4.29
 
 script:
   - make test

--- a/app/config.py
+++ b/app/config.py
@@ -119,8 +119,8 @@ class TestingConfig(DevelopmentConfig):
 
     URL_PATH_PREFIX = ''
 
-    GTM_CONTAINER_ID = 'GTM-MRQGCXS'
-    GTM_TAG_ID = "Dummy?"
+    GTM_CONTAINER_ID = "GTM-XXXXXXX"
+    GTM_TAG_ID = "G-XXXXXXXXXX"
 
     REDIS_SERVER = ''
 

--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,7 @@ class BaseConfig:
     URL_PATH_PREFIX = env('URL_PATH_PREFIX', default='')
 
     GTM_CONTAINER_ID = env('GTM_CONTAINER_ID', default='')
-    GTM_AUTH = env('GTM_AUTH', default='')
+    GTM_TAG_ID = env('GTM_TAG_ID', default='') 
 
     REDIS_SERVER = env('REDIS_SERVER', default='localhost')
 
@@ -90,7 +90,7 @@ class DevelopmentConfig(BaseConfig):
     URL_PATH_PREFIX = env('URL_PATH_PREFIX', default='')
 
     GTM_CONTAINER_ID = env.str('GTM_CONTAINER_ID', default='')
-    GTM_AUTH = env.str('GTM_AUTH', default='')
+    GTM_TAG_ID = env('GTM_TAG_ID', default='')
 
     REDIS_SERVER = env('REDIS_SERVER', default='localhost')
 
@@ -120,7 +120,7 @@ class TestingConfig(DevelopmentConfig):
     URL_PATH_PREFIX = ''
 
     GTM_CONTAINER_ID = 'GTM-MRQGCXS'
-    GTM_AUTH = 'SMijm6Rii1nctiBFRb1Rdw'
+    GTM_TAG_ID = "Dummy?"
 
     REDIS_SERVER = ''
 

--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,7 @@ class BaseConfig:
     URL_PATH_PREFIX = env('URL_PATH_PREFIX', default='')
 
     GTM_CONTAINER_ID = env('GTM_CONTAINER_ID', default='')
-    GTM_TAG_ID = env('GTM_TAG_ID', default='') 
+    GTM_TAG_ID = env('GTM_TAG_ID', default='')
 
     REDIS_SERVER = env('REDIS_SERVER', default='localhost')
 

--- a/app/google_analytics.py
+++ b/app/google_analytics.py
@@ -1,2 +1,2 @@
 async def ga_ua_id_processor(request):
-    return {'gtm_cont_id': request.app['GTM_CONTAINER_ID'], 'gtm_auth': request.app['GTM_AUTH']}
+    return {'gtm_cont_id': request.app['GTM_CONTAINER_ID'], 'gtm_tag_id': request.app['GTM_TAG_ID']}

--- a/app/security.py
+++ b/app/security.py
@@ -23,14 +23,15 @@ CSP = {
     'script-src': [
         "'self'",
         'https://www.googletagmanager.com',
-        'https://www.google-analytics.com',
-        'https://ssl.google-analytics.com',
+        'https://*.googletagmanager.com',
         'https://cdn.ons.gov.uk',
     ],
     'connect-src': [
         "'self'",
         'https://cdn.ons.gov.uk',
-        'https://www.google-analytics.com'
+        'https://*.google-analytics.com', 
+        'https://*.analytics.google.com', 
+        'https://*.googletagmanager.com'
     ],
     'frame-src': [
         'https://www.googletagmanager.com',
@@ -39,7 +40,8 @@ CSP = {
     'img-src': [
         "'self'",
         'data:',
-        'https://www.google-analytics.com',
+        'https://*.google-analytics.com',
+        'https://*.googletagmanager.com',
         'https://ssl.gstatic.com',
         'https://www.gstatic.com',
         'https://cdn.ons.gov.uk'

--- a/app/security.py
+++ b/app/security.py
@@ -17,33 +17,25 @@ CSP = {
     'font-src': [
         "'self'",
         'data:',
-        'https://fonts.gstatic.com',
         'https://cdn.ons.gov.uk',
     ],
     'script-src': [
         "'self'",
-        'https://www.googletagmanager.com',
         'https://*.googletagmanager.com',
         'https://cdn.ons.gov.uk',
     ],
     'connect-src': [
         "'self'",
         'https://cdn.ons.gov.uk',
-        'https://*.google-analytics.com', 
-        'https://*.analytics.google.com', 
+        'https://*.google-analytics.com',
+        'https://*.analytics.google.com',
         'https://*.googletagmanager.com'
-    ],
-    'frame-src': [
-        'https://www.googletagmanager.com',
-        'https://www.timeforstorm.com'
     ],
     'img-src': [
         "'self'",
         'data:',
         'https://*.google-analytics.com',
         'https://*.googletagmanager.com',
-        'https://ssl.gstatic.com',
-        'https://www.gstatic.com',
         'https://cdn.ons.gov.uk'
     ],
 

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -89,13 +89,13 @@
         {%- include 'partials/gtm.html' with context -%}
     {%- endif -%}
 
-{%- endblock -%}
-
-{%- block bodyStart -%}
-
     {%- if gtm_tag_id -%}
         {%- include 'partials/ga.html' with context -%}
     {%- endif -%}
+
+{%- endblock -%}
+
+{%- block bodyStart -%}
 
     {%- if gtm_cont_id -%}
         {%- include 'partials/gtm-no-script.html' with context -%}

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -91,11 +91,11 @@
 
 {%- endblock -%}
 
-{%- if gtm_tag_id -%}
-    {%- include 'partials/ga.html' with context -%}
-{%- endif -%}
-
 {%- block bodyStart -%}
+
+    {%- if gtm_tag_id -%}
+        {%- include 'partials/ga.html' with context -%}
+    {%- endif -%}
 
     {%- if gtm_cont_id -%}
         {%- include 'partials/gtm-no-script.html' with context -%}

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -85,17 +85,15 @@
 
 {%- block head -%}
 
-<!-- Google Analytics -->
-    {%- if gtm_cont_id and gtm_auth -%}
+    {%- if gtm_cont_id -%}
         {%- include 'partials/gtm.html' with context -%}
     {%- endif -%}
-<!-- End Google Analytics -->
 
 {%- endblock -%}
 
 {%- block bodyStart -%}
 
-    {%- if gtm_cont_id and gtm_auth -%}
+    {%- if gtm_cont_id -%}
         {%- include 'partials/gtm-no-script.html' with context -%}
     {%- endif -%}
 

--- a/app/templates/base-cy.html
+++ b/app/templates/base-cy.html
@@ -91,6 +91,10 @@
 
 {%- endblock -%}
 
+{%- if gtm_tag_id -%}
+    {%- include 'partials/ga.html' with context -%}
+{%- endif -%}
+
 {%- block bodyStart -%}
 
     {%- if gtm_cont_id -%}

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -89,17 +89,13 @@
         {%- include 'partials/gtm.html' with context -%}
     {%- endif -%}
 
-{%- endblock -%}
-
-{%- if gtm_tag_id -%}
-    {%- include 'partials/ga.html' with context -%}
-{%- endif -%}
-
-{%- block bodyStart -%}
-
     {%- if gtm_tag_id -%}
     {%- include 'partials/ga.html' with context -%}
     {%- endif -%}
+
+{%- endblock -%}
+
+{%- block bodyStart -%}
 
     {%- if gtm_cont_id -%}
         {%- include 'partials/gtm-no-script.html' with context -%}

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -90,7 +90,7 @@
     {%- endif -%}
 
     {%- if gtm_tag_id -%}
-    {%- include 'partials/ga.html' with context -%}
+        {%- include 'partials/ga.html' with context -%}
     {%- endif -%}
 
 {%- endblock -%}

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -91,6 +91,10 @@
 
 {%- endblock -%}
 
+{%- if gtm_tag_id -%}
+    {%- include 'partials/ga.html' with context -%}
+{%- endif -%}
+
 {%- block bodyStart -%}
 
     {%- if gtm_cont_id -%}

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -85,7 +85,7 @@
 
 {%- block head -%}
 
-    {%- if gtm_cont_id and gtm_auth -%}
+    {%- if gtm_cont_id -%}
         {%- include 'partials/gtm.html' with context -%}
     {%- endif -%}
 
@@ -93,7 +93,7 @@
 
 {%- block bodyStart -%}
 
-    {%- if gtm_cont_id and gtm_auth -%}
+    {%- if gtm_cont_id -%}
         {%- include 'partials/gtm-no-script.html' with context -%}
     {%- endif -%}
 

--- a/app/templates/base-en.html
+++ b/app/templates/base-en.html
@@ -97,6 +97,10 @@
 
 {%- block bodyStart -%}
 
+    {%- if gtm_tag_id -%}
+    {%- include 'partials/ga.html' with context -%}
+    {%- endif -%}
+
     {%- if gtm_cont_id -%}
         {%- include 'partials/gtm-no-script.html' with context -%}
     {%- endif -%}

--- a/app/templates/partials/ga.html
+++ b/app/templates/partials/ga.html
@@ -2,9 +2,13 @@
 <script nonce="{{ cspNonce }}" async src="https://www.googletagmanager.com/gtag/js?id={{ gtm_tag_id }}"></script> 
 
 <script nonce="{{ cspNonce }}">
-    window.dataLayer = window.dataLayer || []; 
-    function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); 
-    gtag('config', '{{ gtm_tag_id }}'); 
+    var allowTrackingCookies = /^(.*)?\s*'campaign':true\s*[^;]+(.*)?$/;
+
+    if (document.cookie.match(allowTrackingCookies)) {
+        window.dataLayer = window.dataLayer || []; 
+        function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); 
+        gtag('config', '{{ gtm_tag_id }}'); 
+    }
 </script>
 
 <!-- End Google tag -->

--- a/app/templates/partials/ga.html
+++ b/app/templates/partials/ga.html
@@ -2,7 +2,7 @@
 <script nonce="{{ cspNonce }}" async src="https://www.googletagmanager.com/gtag/js?id={{ gtm_tag_id }}"></script> 
 
 <script nonce="{{ cspNonce }}">
-    var allowTrackingCookies = /^(.*)?\s*'campaign':true\s*[^;]+(.*)?$/;
+    var allowTrackingCookies = /^(.*)?\s*'campaigns':true\s*[^;]+(.*)?$/;
 
     if (document.cookie.match(allowTrackingCookies)) {
         window.dataLayer = window.dataLayer || []; 

--- a/app/templates/partials/ga.html
+++ b/app/templates/partials/ga.html
@@ -1,0 +1,10 @@
+<!-- Google tag (gtag.js) --> 
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ gtag_id }}"></script> 
+
+<script> 
+    window.dataLayer = window.dataLayer || []; 
+    function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); 
+    gtag('config', '{{ gtag_id }}'); 
+</script>
+
+<!-- End Google tag -->

--- a/app/templates/partials/ga.html
+++ b/app/templates/partials/ga.html
@@ -1,7 +1,7 @@
 <!-- Google tag (gtag.js) --> 
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ gtm_tag_id }}"></script> 
+<script nonce="{{ cspNonce }}" async src="https://www.googletagmanager.com/gtag/js?id={{ gtm_tag_id }}"></script> 
 
-<script> 
+<script nonce="{{ cspNonce }}">
     window.dataLayer = window.dataLayer || []; 
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); 
     gtag('config', '{{ gtm_tag_id }}'); 

--- a/app/templates/partials/ga.html
+++ b/app/templates/partials/ga.html
@@ -1,10 +1,10 @@
 <!-- Google tag (gtag.js) --> 
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ gtag_id }}"></script> 
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ gtm_tag_id }}"></script> 
 
 <script> 
     window.dataLayer = window.dataLayer || []; 
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); 
-    gtag('config', '{{ gtag_id }}'); 
+    gtag('config', '{{ gtm_tag_id }}'); 
 </script>
 
 <!-- End Google tag -->

--- a/app/templates/partials/gtm-no-script.html
+++ b/app/templates/partials/gtm-no-script.html
@@ -1,4 +1,6 @@
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_cont_id }}&gtm_auth={{ gtm_auth }}&gtm_cookies_win=x"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_cont_id }}" height="0" width="0" style="display:none;visibility:hidden">
+    </iframe>
+</noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/app/templates/partials/gtm.html
+++ b/app/templates/partials/gtm.html
@@ -1,18 +1,12 @@
 <!-- Google Tag Manager -->
-<script nonce="{{ cspNonce }}">
-    function loadGTM() {
-        (function (w, d, s, l, i) {
-            w[l] = w[l] || []; w[l].push({
-                'gtm.start':
-                    new Date().getTime(), event: 'gtm.js'
-            }); var f = d.getElementsByTagName(s)[0],
-                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-                    'https://www.googletagmanager.com/gtm.js?id=' + i + dl + '&gtm_auth={{ gtm_auth }}&gtm_cookies_win=x'; f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'dataLayer', '{{ gtm_cont_id }}');
-    }
-    var a = /^(.*)?\s*'usage':true\s*[^;]+(.*)?$/;
-    if (document.cookie.match(a)) {
-        loadGTM();
-    }
+<script>
+    (function(w,d,s,l,i){
+        w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+        var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+        j.async=true;
+        j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+        f.parentNode.insertBefore(j,f);
+    })
+    (window,document,'script','dataLayer','{{ gtm_cont_id }}');
 </script>
 <!-- End Google Tag Manager -->

--- a/app/templates/partials/gtm.html
+++ b/app/templates/partials/gtm.html
@@ -1,12 +1,16 @@
 <!-- Google Tag Manager -->
 <script nonce="{{ cspNonce }}">
-    (function(w,d,s,l,i){
-        w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-        var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-        j.async=true;
-        j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-        f.parentNode.insertBefore(j,f);
-    })
-    (window,document,'script','dataLayer','{{ gtm_cont_id }}');
+    var allowTrackingCookies = /^(.*)?\s*'campaign':true\s*[^;]+(.*)?$/;
+
+    if (document.cookie.match(allowTrackingCookies)) {
+        (function(w,d,s,l,i){
+            w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+            var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+            j.async=true;
+            j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+            f.parentNode.insertBefore(j,f);
+        })
+        (window,document,'script','dataLayer','{{ gtm_cont_id }}');
+    }
 </script>
 <!-- End Google Tag Manager -->

--- a/app/templates/partials/gtm.html
+++ b/app/templates/partials/gtm.html
@@ -1,6 +1,6 @@
 <!-- Google Tag Manager -->
 <script nonce="{{ cspNonce }}">
-    var allowTrackingCookies = /^(.*)?\s*'campaign':true\s*[^;]+(.*)?$/;
+    var allowTrackingCookies = /^(.*)?\s*'campaigns':true\s*[^;]+(.*)?$/;
 
     if (document.cookie.match(allowTrackingCookies)) {
         (function(w,d,s,l,i){

--- a/app/templates/partials/gtm.html
+++ b/app/templates/partials/gtm.html
@@ -1,5 +1,5 @@
 <!-- Google Tag Manager -->
-<script>
+<script nonce="{{ cspNonce }}">
     (function(w,d,s,l,i){
         w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
         var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';

--- a/kubernetes/dev.yml
+++ b/kubernetes/dev.yml
@@ -44,11 +44,11 @@ spec:
         - name: http-server
           containerPort: 9092
         env:
-        - name: GTM_AUTH
+        - name: GTM_TAG_ID
           valueFrom:
             secretKeyRef:
               name: google-analytics
-              key: google-analytics-prop
+              key: gtm-tag-id
               optional: true
         - name: GTM_CONTAINER_ID
           valueFrom:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -40,35 +40,19 @@ class TestCreateApp(AioHTTPTestCase):
                          'max-age=31536000; includeSubDomains')
         self.assertIn("default-src 'self' https://cdn.ons.gov.uk",
                       response.headers['Content-Security-Policy'])
-        self.assertIn("font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk",
-                      response.headers['Content-Security-Policy'])
         self.assertIn(
-            f"script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com "
-            f"https://ssl.google-analytics.com https://cdn.ons.gov.uk 'nonce-{nonce}'",
+            f"script-src 'self' https://*.googletagmanager.com https://cdn.ons.gov.uk 'nonce-{nonce}'",
             response.headers['Content-Security-Policy'])
         self.assertIn(
-            "frame-src https://www.googletagmanager.com https://www.timeforstorm.com",
+            "connect-src 'self' https://cdn.ons.gov.uk https://*.google-analytics.com "
+            "https://*.analytics.google.com https://*.googletagmanager.com;",
             response.headers['Content-Security-Policy'])
         self.assertIn(
-            "img-src 'self' data: https://www.google-analytics.com https://ssl.gstatic.com "
-            "https://www.gstatic.com https://cdn.ons.gov.uk",
+            "img-src 'self' data: https://*.google-analytics.com https://*.googletagmanager.com https://cdn.ons.gov.uk",
             response.headers['Content-Security-Policy'])
         self.assertEqual(response.headers['X-Content-Type-Options'], 'nosniff')
         self.assertIn("default-src 'self' https://cdn.ons.gov.uk",
                       response.headers['X-Content-Security-Policy'])
-        self.assertIn("font-src 'self' data: https://fonts.gstatic.com https://cdn.ons.gov.uk",
-                      response.headers['X-Content-Security-Policy'])
-        self.assertIn(
-            f"script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com "
-            f"https://ssl.google-analytics.com https://cdn.ons.gov.uk 'nonce-{nonce}'",
-            response.headers['X-Content-Security-Policy'])
-        self.assertIn(
-            "frame-src https://www.googletagmanager.com https://www.timeforstorm.com",
-            response.headers['X-Content-Security-Policy'])
-        self.assertIn(
-            "img-src 'self' data: https://www.google-analytics.com https://ssl.gstatic.com "
-            "https://www.gstatic.com https://cdn.ons.gov.uk",
-            response.headers['X-Content-Security-Policy'])
         self.assertEqual(response.headers['Referrer-Policy'], 'strict-origin-when-cross-origin')
         self.assertEqual(response.headers['X-Permitted-Cross-Domain-Policies'], 'None')
 

--- a/tests/unit/test_google_analytics.py
+++ b/tests/unit/test_google_analytics.py
@@ -6,16 +6,12 @@ from tests.unit import RHTestCase
 
 class TestGoogleAnalytics(RHTestCase):
     async def test_google_analytics_context(self):
-        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_TAG_ID'] = 'G-XXXXXXXXXX'
         request = make_mocked_request('GET', '/', app=self.app)
         context = await ga_ua_id_processor(request)
         self.assertEqual(context['gtm_cont_id'], 'GTM-XXXXXXX')
         self.assertEqual(context['gtm_tag_id'], 'G-XXXXXXXXXX')
 
     async def test_google_analytics_script_rendered_base_en(self):
-        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_TAG_ID'] = 'G-XXXXXXXXXX'
         response = await self.client.request('GET', self.get_start_en)
         self.assertEqual(response.status, 200)
         response = await response.content.read()
@@ -23,8 +19,6 @@ class TestGoogleAnalytics(RHTestCase):
         self.assertIn("https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX".encode(), response)
 
     async def test_google_analytics_script_rendered_base_cy(self):
-        self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_TAG_ID'] = 'G-XXXXXXXXXX'
         response = await self.client.request('GET', self.get_start_cy)
         self.assertEqual(response.status, 200)
         response = await response.content.read()

--- a/tests/unit/test_google_analytics.py
+++ b/tests/unit/test_google_analytics.py
@@ -7,29 +7,29 @@ from tests.unit import RHTestCase
 class TestGoogleAnalytics(RHTestCase):
     async def test_google_analytics_context(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_TAG_ID'] = '12345'
+        self.app['GTM_TAG_ID'] = 'G-XXXXXXXXXX'
         request = make_mocked_request('GET', '/', app=self.app)
         context = await ga_ua_id_processor(request)
         self.assertEqual(context['gtm_cont_id'], 'GTM-XXXXXXX')
-        self.assertEqual(context['gtm_tag_id'], '12345')
+        self.assertEqual(context['gtm_tag_id'], 'G-XXXXXXXXXX')
 
     async def test_google_analytics_script_rendered_base_en(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_TAG_ID'] = 'G-1234567890'
+        self.app['GTM_TAG_ID'] = 'G-XXXXXXXXXX'
         response = await self.client.request('GET', self.get_start_en)
         self.assertEqual(response.status, 200)
         response = await response.content.read()
         self.assertIn("(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
-        self.assertIn("https://www.googletagmanager.com/gtag/js?id=G-1234567890".encode(), response)
+        self.assertIn("https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX".encode(), response)
 
     async def test_google_analytics_script_rendered_base_cy(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_TAG_ID'] = '12345'
+        self.app['GTM_TAG_ID'] = 'G-XXXXXXXXXX'
         response = await self.client.request('GET', self.get_start_cy)
         self.assertEqual(response.status, 200)
         response = await response.content.read()
         self.assertIn("(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
-        self.assertIn("https://www.googletagmanager.com/gtag/js?id=12345".encode(), response)
+        self.assertIn("https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX".encode(), response)
 
     async def test_google_analytics_script_not_rendered_missing_container_id_base_en(self):
         self.app['GTM_CONTAINER_ID'] = ''

--- a/tests/unit/test_google_analytics.py
+++ b/tests/unit/test_google_analytics.py
@@ -15,21 +15,21 @@ class TestGoogleAnalytics(RHTestCase):
 
     async def test_google_analytics_script_rendered_base_en(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_AUTH'] = '12345'
+        self.app['GTM_TAG_ID'] = '12345'
         response = await self.client.request('GET', self.get_start_en)
         self.assertEqual(response.status, 200)
         response = await response.content.read()
         self.assertIn("window, document, \'script\', \'dataLayer\', \'GTM-XXXXXXX\');".encode(), response)
-        self.assertIn("gtm_auth=12345&gtm_cookies_win=x".encode(), response)
+        self.assertIn("https://www.googletagmanager.com/gtag/js?id=12345".encode(), response)
 
     async def test_google_analytics_script_rendered_base_cy(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_AUTH'] = '12345'
+        self.app['GTM_TAG_ID'] = '12345'
         response = await self.client.request('GET', self.get_start_cy)
         self.assertEqual(response.status, 200)
         response = await response.content.read()
         self.assertIn("(window, document, \'script\', \'dataLayer\', \'GTM-XXXXXXX\');".encode(), response)
-        self.assertIn("gtm_auth=12345&gtm_cookies_win=x".encode(), response)
+        self.assertIn("https://www.googletagmanager.com/gtag/js?id=12345".encode(), response)
 
     async def test_google_analytics_script_not_rendered_missing_container_id_base_en(self):
         self.app['GTM_CONTAINER_ID'] = ''
@@ -48,15 +48,15 @@ class TestGoogleAnalytics(RHTestCase):
                          await response.content.read())
 
     async def test_google_analytics_script_not_rendered_base_en(self):
-        self.app['GTM_AUTH'] = ''
+        self.app['GTM_TAG_ID'] = ''
 
         response = await self.client.request('GET', self.get_start_en)
         self.assertEqual(response.status, 200)
-        self.assertNotIn("gtm_auth=12345&gtm_cookies_win=x".encode(), await response.content.read())
+        self.assertNotIn("https://www.googletagmanager.com/gtag/js?id=12345".encode(), await response.content.read())
 
     async def test_google_analytics_script_not_rendered_base_cy(self):
-        self.app['GTM_AUTH'] = ''
+        self.app['GTM_TAG_ID'] = ''
 
         response = await self.client.request('GET', self.get_start_cy)
         self.assertEqual(response.status, 200)
-        self.assertNotIn("gtm_auth=12345&gtm_cookies_win=x".encode(), await response.content.read())
+        self.assertNotIn("https://www.googletagmanager.com/gtag/js?id=12345".encode(), await response.content.read())

--- a/tests/unit/test_google_analytics.py
+++ b/tests/unit/test_google_analytics.py
@@ -7,11 +7,11 @@ from tests.unit import RHTestCase
 class TestGoogleAnalytics(RHTestCase):
     async def test_google_analytics_context(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_AUTH'] = '12345'
+        self.app['GTM_TAG_ID'] = '12345'
         request = make_mocked_request('GET', '/', app=self.app)
         context = await ga_ua_id_processor(request)
         self.assertEqual(context['gtm_cont_id'], 'GTM-XXXXXXX')
-        self.assertEqual(context['gtm_auth'], '12345')
+        self.assertEqual(context['gtm_tag_id'], '12345')
 
     async def test_google_analytics_script_rendered_base_en(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'

--- a/tests/unit/test_google_analytics.py
+++ b/tests/unit/test_google_analytics.py
@@ -15,12 +15,12 @@ class TestGoogleAnalytics(RHTestCase):
 
     async def test_google_analytics_script_rendered_base_en(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
-        self.app['GTM_TAG_ID'] = '12345'
+        self.app['GTM_TAG_ID'] = 'G-1234567890'
         response = await self.client.request('GET', self.get_start_en)
         self.assertEqual(response.status, 200)
         response = await response.content.read()
-        self.assertIn("window, document, \'script\', \'dataLayer\', \'GTM-XXXXXXX\');".encode(), response)
-        self.assertIn("https://www.googletagmanager.com/gtag/js?id=12345".encode(), response)
+        self.assertIn("(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
+        self.assertIn("https://www.googletagmanager.com/gtag/js?id=G-1234567890".encode(), response)
 
     async def test_google_analytics_script_rendered_base_cy(self):
         self.app['GTM_CONTAINER_ID'] = 'GTM-XXXXXXX'
@@ -28,7 +28,7 @@ class TestGoogleAnalytics(RHTestCase):
         response = await self.client.request('GET', self.get_start_cy)
         self.assertEqual(response.status, 200)
         response = await response.content.read()
-        self.assertIn("(window, document, \'script\', \'dataLayer\', \'GTM-XXXXXXX\');".encode(), response)
+        self.assertIn("(window,document,\'script\',\'dataLayer\',\'GTM-XXXXXXX\');".encode(), response)
         self.assertIn("https://www.googletagmanager.com/gtag/js?id=12345".encode(), response)
 
     async def test_google_analytics_script_not_rendered_missing_container_id_base_en(self):


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We've been told to update the version of GTM

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

Added the new GA code snippet 
Removed deprecated gtm-auth variable, added new gtm-tag-id variable
Updated the unit tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

Pull from this branch, run `make build`

Add:
```
- GTM_CONTAINER_ID=GTM-XXXXXXX
- GTM_TAG_ID=G-XXXXXXXXXX
```
to the env variables for RH-UI in rm-services.yml in your docker-dev, run ```make up```

Go to http://localhost:9092/en/start/  open Chrome dev tools and look for GTM-XXXXXXX and G-XXXXXXXXXX in the page source

**Note:** 
the ga script will is currently in the body rather than immediately after the ```head``` element as the email instructs, because that's not possible with the way the design system is implemented (we'll find out if it still works when it's deployed to pre-prod)

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
I don't have a link to that, but refer to Ian Oliver's email on our team mailbox
https://trello.com/c/NJdGCGHf/943-google-analytics-implement-code-snippets-in-rh-ui-5

# Screenshots (if appropriate):