### PR TITLE
changed aioredis import to redis.asyncio

### DIFF
--- a/app/session.py
+++ b/app/session.py
@@ -2,7 +2,7 @@ import asyncio
 
 from aiohttp_session import Session, get_session, session_middleware
 from aiohttp_session.redis_storage import RedisStorage
-from aioredis import RedisError, from_url
+from redis.asyncio import from_url, RedisError
 from structlog import get_logger
 
 from app.exceptions import SessionTimeout


### PR DESCRIPTION
# Motivation and Context
RH-UI build failed as aioredis had been migrated to redis in the most recent version of aiohttp-session

# What has changed
Changed import to import redis instead

# How to test?
- Build and test locally

# Links
https://trello.com/c/H4EyO7oS

# Screenshots (if appropriate):